### PR TITLE
Refactored settings GUI and logic to store credential into QGIS auth infrastructure. Fixes #354 #341

### DIFF
--- a/LDMP/api.py
+++ b/LDMP/api.py
@@ -35,6 +35,7 @@ from qgis.core import (
 from LDMP.worker import AbstractWorker, start_worker
 
 from LDMP import log, debug_on
+from LDMP.message_bar import MessageBar
 
 API_URL = 'https://api.trends.earth'
 TIMEOUT = 20
@@ -71,12 +72,12 @@ def init_auth_config(email=None):
     if not previousAuthExist:
         # store a new auth config
         if not QgsApplication.authManager().storeAuthenticationConfig(currentAuthConfig):
-            iface.messageBar().pushCritical('Trends.Earth', tr_api.tr('Cannot init auth configuration'))
+            MessageBar().get().pushCritical('Trends.Earth', tr_api.tr('Cannot init auth configuration'))
             return None
     else:
         # update existing
          if not QgsApplication.authManager().updateAuthenticationConfig(currentAuthConfig):
-            iface.messageBar().pushCritical('Trends.Earth', tr_api.tr('Cannot update auth configuration'))
+            MessageBar().get().pushCritical('Trends.Earth', tr_api.tr('Cannot update auth configuration'))
             return None
 
     QSettings().setValue("trends_earth/authId", currentAuthConfig.id())
@@ -85,12 +86,12 @@ def init_auth_config(email=None):
 def remove_current_auth_config():
     authConfigId = QSettings().value("trends_earth/authId", None)
     if not authConfigId:
-        iface.messageBar().pushCritical('Trends.Earth', tr_api.tr('No authentication set. Do it in Trends.Earth settings'))
+        MessageBar().get().pushCritical('Trends.Earth', tr_api.tr('No authentication set. Do it in Trends.Earth settings'))
         return None
     log('remove_current_auth_config with authId {}'.format(authConfigId))
 
     if not QgsApplication.authManager().removeAuthenticationConfig( authConfigId ):
-        iface.messageBar().pushCritical('Trends.Earth', tr_api.tr('Cannot remove auth configuration with id: {}').format(authConfigId))
+        MessageBar().get().pushCritical('Trends.Earth', tr_api.tr('Cannot remove auth configuration with id: {}').format(authConfigId))
         return False
 
     QSettings().setValue("trends_earth/authId", None)
@@ -102,32 +103,32 @@ def get_auth_config(authConfigId=None, warn=True):
         authConfigId = QSettings().value("trends_earth/authId", None)
         if not authConfigId:
             if warn:
-                iface.messageBar().pushCritical('Trends.Earth', tr_api.tr('No authentication set. Do it in Trends.Earth settings'))
+                MessageBar().get().pushCritical('Trends.Earth', tr_api.tr('No authentication set. Do it in Trends.Earth settings'))
             return None
     log('get_auth_config with authId {}'.format(authConfigId))
 
     configs = QgsApplication.authManager().availableAuthMethodConfigs()
     if not authConfigId in configs.keys():
         if warn:
-            iface.messageBar().pushCritical('Trends.Earth', tr_api.tr('Cannot retrieve credentials with authId: {} setup correct credentials before').format(authConfigId))
+            MessageBar().get().pushCritical('Trends.Earth', tr_api.tr('Cannot retrieve credentials with authId: {} setup correct credentials before').format(authConfigId))
         return None
 
     authConfig = QgsAuthMethodConfig()
     ok = QgsApplication.authManager().loadAuthenticationConfig(authConfigId, authConfig, True)
     if not ok:
         if warn:
-            iface.messageBar().pushCritical('Trends.Earth', tr_api.tr('Cannot retrieve credentials with authId: {} setup correct credentials before').format(authConfigId))
+            MessageBar().get().pushCritical('Trends.Earth', tr_api.tr('Cannot retrieve credentials with authId: {} setup correct credentials before').format(authConfigId))
         return None
     
     if not authConfig.isValid():
         if warn:
-            iface.messageBar().pushCritical('Trends.Earth', tr_api.tr('Not valid auth configuration with authId: {}').format(authConfigId))
+            MessageBar().get().pushCritical('Trends.Earth', tr_api.tr('Not valid auth configuration with authId: {}').format(authConfigId))
         return None
 
     # check if auth method is the only supported for no
     if authConfig.method() != 'Basic':
         if warn:
-            iface.messageBar().pushCritical('Trends.Earth',
+            MessageBar().get().pushCritical('Trends.Earth',
                 tr_api.tr('Auth method with authId: {} is {}. Only basic auth is supported by Trend.Earth').format( authConfigId, authConfig.method() ))
         return None
     

--- a/LDMP/gui/DlgSettings.ui
+++ b/LDMP/gui/DlgSettings.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>284</width>
-    <height>487</height>
+    <width>462</width>
+    <height>360</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -50,108 +50,126 @@
       </font>
      </property>
      <property name="title">
-      <string>New users</string>
+      <string>Trends.Earth remote server</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
-       <widget class="QLabel" name="label">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="font">
-         <font>
-          <weight>50</weight>
-          <bold>false</bold>
-         </font>
-        </property>
-        <property name="text">
-         <string>Click the below button to register with Trends.Earth.</string>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-       </widget>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QgsAuthConfigSelect" name="authConfigSelect_authentication">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>30</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <weight>50</weight>
+            <bold>false</bold>
+           </font>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="pushButton_login">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>30</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <weight>50</weight>
+            <bold>false</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>Test connection</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
       <item>
-       <widget class="QPushButton" name="pushButton_register">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>30</height>
-         </size>
-        </property>
-        <property name="font">
-         <font>
-          <weight>75</weight>
-          <bold>true</bold>
-         </font>
-        </property>
-        <property name="text">
-         <string>Step 1: Register</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLabel" name="label_2">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="font">
-         <font>
-          <weight>50</weight>
-          <bold>false</bold>
-         </font>
-        </property>
-        <property name="text">
-         <string>After registering, you will receive an email with your password from api@trends.earth. Once you receive that email, click below to enter that password to login to Trends.Earth.</string>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="pushButton_login">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>30</height>
-         </size>
-        </property>
-        <property name="font">
-         <font>
-          <weight>50</weight>
-          <bold>false</bold>
-         </font>
-        </property>
-        <property name="text">
-         <string>Step 2: Enter login</string>
-        </property>
-       </widget>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QPushButton" name="pushButton_register">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>30</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <weight>50</weight>
+            <bold>false</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>Register</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="pushButton_edit">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>30</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <weight>50</weight>
+            <bold>false</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>Manage user account</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>
@@ -174,31 +192,6 @@
       <string>Existing users</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
-       <widget class="QPushButton" name="pushButton_edit">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>30</height>
-         </size>
-        </property>
-        <property name="font">
-         <font>
-          <weight>50</weight>
-          <bold>false</bold>
-         </font>
-        </property>
-        <property name="text">
-         <string>Update account</string>
-        </property>
-       </widget>
-      </item>
       <item>
        <widget class="QPushButton" name="pushButton_forgot_pwd">
         <property name="sizePolicy">
@@ -288,6 +281,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsAuthConfigSelect</class>
+   <extends>QWidget</extends>
+   <header>qgis.gui</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/LDMP/gui/DlgSettings.ui
+++ b/LDMP/gui/DlgSettings.ui
@@ -9,26 +9,26 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>462</width>
-    <height>360</height>
+    <width>500</width>
+    <height>291</height>
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
   <property name="minimumSize">
    <size>
-    <width>250</width>
+    <width>500</width>
     <height>0</height>
    </size>
   </property>
   <property name="windowTitle">
    <string>Settings</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_4">
+  <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
     <widget class="QGroupBox" name="groupBox">
      <property name="sizePolicy">
@@ -45,8 +45,8 @@
      </property>
      <property name="font">
       <font>
-       <weight>75</weight>
-       <bold>true</bold>
+       <weight>50</weight>
+       <bold>false</bold>
       </font>
      </property>
      <property name="title">
@@ -80,7 +80,7 @@
         <item>
          <widget class="QPushButton" name="pushButton_login">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
@@ -88,7 +88,7 @@
           <property name="minimumSize">
            <size>
             <width>0</width>
-            <height>30</height>
+            <height>0</height>
            </size>
           </property>
           <property name="font">
@@ -109,14 +109,14 @@
         <item>
          <widget class="QPushButton" name="pushButton_register">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
           <property name="minimumSize">
            <size>
-            <width>0</width>
+            <width>80</width>
             <height>30</height>
            </size>
           </property>
@@ -132,17 +132,17 @@
          </widget>
         </item>
         <item>
-         <widget class="QPushButton" name="pushButton_edit">
+         <widget class="QPushButton" name="pushButton_update_profile">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
           <property name="minimumSize">
            <size>
-            <width>0</width>
-            <height>30</height>
+            <width>120</width>
+            <height>0</height>
            </size>
           </property>
           <property name="font">
@@ -152,7 +152,26 @@
            </font>
           </property>
           <property name="text">
-           <string>Manage user account</string>
+           <string>Update profile</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="pushButton_forgot_pwd">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>120</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Reset password</string>
           </property>
          </widget>
         </item>
@@ -169,53 +188,26 @@
           </property>
          </spacer>
         </item>
+        <item>
+         <widget class="QPushButton" name="pushButton_delete_user">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>100</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Delete user</string>
+          </property>
+         </widget>
+        </item>
        </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_2">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="font">
-      <font>
-       <weight>50</weight>
-       <bold>false</bold>
-      </font>
-     </property>
-     <property name="title">
-      <string>Existing users</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
-       <widget class="QPushButton" name="pushButton_forgot_pwd">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>30</height>
-         </size>
-        </property>
-        <property name="font">
-         <font>
-          <weight>50</weight>
-          <bold>false</bold>
-         </font>
-        </property>
-        <property name="text">
-         <string>Reset password</string>
-        </property>
-       </widget>
       </item>
      </layout>
     </widget>
@@ -265,6 +257,19 @@
       </item>
      </layout>
     </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>39</height>
+      </size>
+     </property>
+    </spacer>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">

--- a/LDMP/gui/DlgSettingsEdit.ui
+++ b/LDMP/gui/DlgSettingsEdit.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>199</width>
-    <height>197</height>
+    <width>291</width>
+    <height>235</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -77,6 +77,31 @@
      </property>
      <property name="text">
       <string>Update profile</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="pushButton_forgot_pwd">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>30</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <weight>50</weight>
+       <bold>false</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Reset password</string>
      </property>
     </widget>
    </item>

--- a/LDMP/gui/DlgSettingsEdit.ui
+++ b/LDMP/gui/DlgSettingsEdit.ui
@@ -37,25 +37,6 @@
     </widget>
    </item>
    <item>
-    <widget class="QPushButton" name="pushButton_change_user">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>30</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>Change user</string>
-     </property>
-    </widget>
-   </item>
-   <item>
     <widget class="QPushButton" name="pushButton_update_profile">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Minimum" vsizetype="Minimum">

--- a/LDMP/gui/DlgSettingsEditForgotPassword.ui
+++ b/LDMP/gui/DlgSettingsEditForgotPassword.ui
@@ -6,15 +6,21 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>218</width>
-    <height>128</height>
+    <width>500</width>
+    <height>130</height>
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>500</width>
+    <height>0</height>
+   </size>
   </property>
   <property name="windowTitle">
    <string>Forgot password</string>
@@ -51,6 +57,19 @@
       <string>Enter your email address...</string>
      </property>
     </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>7</height>
+      </size>
+     </property>
+    </spacer>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">

--- a/LDMP/message_bar.py
+++ b/LDMP/message_bar.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+"""
+/***************************************************************************
+ LDMP - A QGIS plugin
+ This plugin supports monitoring and reporting of land degradation to the UNCCD 
+ and in support of the SDG Land Degradation Neutrality (LDN) target.
+                              -------------------
+        begin                : 2017-05-23
+        git sha              : $Format:%H$
+        copyright            : (C) 2017 by Conservation International
+        email                : trends.earth@conservation.org
+ ***************************************************************************/
+"""
+
+from qgis.gui import QgsMessageBar
+from qgis.utils import iface
+
+# singleton decorator
+def singleton(cls):
+    instances = {}
+    def wrapper(*args, **kwargs):
+        if cls not in instances:
+          instances[cls] = cls(*args, **kwargs)
+        return instances[cls]
+    return wrapper
+
+@singleton
+class MessageBar(object):
+
+    def __init__ (self):
+        self.reset()
+
+    def init(self):
+        self._message_bar_ = QgsMessageBar()
+
+    def get(self):
+        return self._message_bar_
+    
+    def reset(self):
+        self._message_bar_ = iface.messageBar()

--- a/LDMP/settings.py
+++ b/LDMP/settings.py
@@ -251,7 +251,6 @@ class DlgSettingsEdit(QtWidgets.QDialog, Ui_DlgSettingsEdit):
 
         self.setupUi(self)
 
-        self.pushButton_change_user.clicked.connect(self.change_user)
         self.pushButton_update_profile.clicked.connect(self.update_profile)
         self.pushButton_delete_user.clicked.connect(self.delete)
         self.pushButton_forgot_pwd.clicked.connect(self.forgot_pwd)
@@ -259,12 +258,6 @@ class DlgSettingsEdit(QtWidgets.QDialog, Ui_DlgSettingsEdit):
         self.buttonBox.rejected.connect(self.close)
 
         self.ok = False
-
-    def change_user(self):
-        dlg_settings_change_user = DlgSettingsLogin()
-        ret = dlg_settings_change_user.exec_()
-        if ret and dlg_settings_change_user.ok:
-            self.close()
 
     def update_profile(self):
         user = get_user()

--- a/LDMP/settings.py
+++ b/LDMP/settings.py
@@ -18,12 +18,10 @@ import re
 import zipfile
 from pathlib import Path
 
-from qgis.PyQt.QtCore import QSettings, pyqtSignal
+from qgis.PyQt.QtCore import QSettings, pyqtSignal, Qt
 from qgis.PyQt import QtWidgets
 
-from qgis.utils import iface
 from qgis.core import QgsApplication
-mb = iface.messageBar()
 
 from LDMP.gui.DlgSettings import Ui_DlgSettings
 from LDMP.gui.DlgSettingsEdit import Ui_DlgSettingsEdit
@@ -47,6 +45,7 @@ from LDMP.api import (
     AUTH_CONFIG_NAME
 )
 from LDMP.download import download_files, get_admin_bounds
+from LDMP.message_bar import MessageBar
 
 settings = QSettings()
 
@@ -94,6 +93,16 @@ class DlgSettings(QtWidgets.QDialog, Ui_DlgSettings):
         # load gui default value from settings
         self.reloadAuthConfigurations()
 
+    def showEvent(self, event):
+        super(DlgSettings, self).showEvent(event)
+        # add message bar for all dialog communication
+        MessageBar().init()
+        self.layout().insertWidget( 0, MessageBar().get() )
+
+    def close(self):
+        super(DlgSettings, self).close()
+        MessageBar().reset()
+
     def reloadAuthConfigurations(self):
         self.authConfigSelect_authentication.populateConfigSelector()
         self.authConfigSelect_authentication.clearMessage()
@@ -115,7 +124,7 @@ class DlgSettings(QtWidgets.QDialog, Ui_DlgSettings):
         # retrieve basic auth from QGIS authManager
         authConfigId = self.authConfigSelect_authentication.configId()
         if not authConfigId:
-            iface.messageBar().pushCritical('Trends.Earth', self.tr('Please select a authentication profile'))
+            MessageBar().get().pushCritical('Trends.Earth', self.tr('Please select a authentication profile'))
             return
 
         # try to login with current credentials

--- a/LDMP/worker.py
+++ b/LDMP/worker.py
@@ -26,6 +26,7 @@ from qgis.PyQt.QtCore import QThread, Qt, QEventLoop, QCoreApplication
 from qgis.PyQt.QtWidgets import QProgressBar, QPushButton
 
 from LDMP import log
+from LDMP.message_bar import MessageBar
 
 
 class tr_worker(object):
@@ -84,8 +85,7 @@ class UserAbortedNotification(Exception):
 
 
 def start_worker(worker, iface, message, with_progress=True):
-    # configure the QgsMessageBar
-    message_bar_item = iface.messageBar().createMessage(message)
+    message_bar_item = MessageBar().get().createMessage(message)
     progress_bar = QProgressBar()
     progress_bar.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
     if not with_progress:
@@ -96,7 +96,7 @@ def start_worker(worker, iface, message, with_progress=True):
     cancel_button.clicked.connect(worker.kill)
     message_bar_item.layout().addWidget(progress_bar)
     message_bar_item.layout().addWidget(cancel_button)
-    iface.messageBar().pushWidget(message_bar_item, Qgis.Info)
+    MessageBar().get().pushWidget(message_bar_item, Qgis.Info)
 
     # start the worker in a new thread
     # let Qt take ownership of the QThread
@@ -123,12 +123,12 @@ def start_worker(worker, iface, message, with_progress=True):
 
 def worker_killed(result, thread, worker, iface, message_bar_item):
     # remove widget from message bar
-    #iface.messageBar().popWidget(message_bar_item)
+    # MessageBar().get().popWidget(message_bar_item)
     pass
 
 def worker_finished(result, thread, worker, iface, message_bar_item):
     # remove widget from message bar
-    iface.messageBar().popWidget(message_bar_item)
+    MessageBar().get().popWidget(message_bar_item)
     if result is not None:
         worker.successfully_finished.emit(result)
 


### PR DESCRIPTION
Refactored Settings to store credentials into QGIS auth infrastructure with minimal changes in original code.

Fixes #354 #341

TODO: decide what to do with "change user" functionality. In this moment current Auth config is sores in .ini under trends_earth section. In case changing auth config this value should be changed.