### PR TITLE
Change location of region configuration into settings dialogue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ invoke.yaml
 trends.earth_admin_user_credentials.json
 trends.earth_test_user_credentials.json
 .ipynb_checkpoints
+.idea/

--- a/LDMP/__init__.py
+++ b/LDMP/__init__.py
@@ -108,6 +108,7 @@ def binaries_available():
 def debug_on():
     QSettings().value("LDMP/debug", False) == 'True'
 
+
 def openFolder(path):
     if not path:
         return

--- a/LDMP/calculate.py
+++ b/LDMP/calculate.py
@@ -852,7 +852,7 @@ class DlgCalculateBase(QtWidgets.QDialog):
         if self.settings.value("trends_earth/region_of_interest/chosen_method") == 'country_region' or \
                 self.settings.value("trends_earth/region_of_interest/chosen_method") == 'country_city':
             if self.settings.value("trends_earth/region_of_interest/chosen_method") == 'country_city':
-                if not self.settings.value("trends_earth/region_of_interest/buffer_checked"):
+                if self.settings.value("trends_earth/region_of_interest/buffer_checked") != 'True':
                     QtWidgets.QMessageBox.critical(None,tr_calculate.tr("Error"),
                            tr_calculate.tr("You have chosen to run calculations for a city."
                                             "You must select a buffer distance to define the "

--- a/LDMP/calculate.py
+++ b/LDMP/calculate.py
@@ -28,7 +28,8 @@ from qgis.PyQt.QtCore import (QTextCodec, QSettings, pyqtSignal,
 from qgis.core import (QgsFeature, QgsPointXY, QgsGeometry, QgsJsonUtils,
     QgsVectorLayer, QgsCoordinateTransform, QgsCoordinateReferenceSystem,
     Qgis, QgsProject, QgsLayerTreeGroup, QgsLayerTreeLayer,
-    QgsVectorFileWriter, QgsFields, QgsWkbTypes)
+    QgsVectorFileWriter, QgsFields, QgsWkbTypes,
+    QgsSettings)
 from qgis.utils import iface
 from qgis.gui import QgsMapToolEmitPoint, QgsMapToolPan
 
@@ -645,6 +646,7 @@ class CalculationOptionsWidget(QtWidgets.QWidget, Ui_WidgetCalculationOptions):
             self.where_to_run_enabled = False
             self.groupBox_where_to_run.hide()
 
+
 class CalculationOutputWidget(QtWidgets.QWidget, Ui_WidgetCalculationOutput):
     def __init__(self, suffixes, subclass_name, parent=None):
         super(CalculationOutputWidget, self).__init__(parent)
@@ -704,222 +706,6 @@ class CalculationOutputWidget(QtWidgets.QWidget, Ui_WidgetCalculationOutput):
         return True
 
 
-class AreaWidget(QtWidgets.QWidget, Ui_WidgetSelectArea):
-    def __init__(self, parent=None):
-        super(AreaWidget, self).__init__(parent)
-
-        self.setupUi(self)
-
-        self.canvas = iface.mapCanvas()
-
-        self.admin_bounds_key = get_admin_bounds()
-        if not self.admin_bounds_key:
-            raise ValueError('Admin boundaries not available')
-
-        self.cities = get_cities()
-        if not self.cities:
-            raise ValueError('Cities list not available')
-
-        # Populate
-        self.area_admin_0.addItems(sorted(self.admin_bounds_key.keys()))
-        self.populate_admin_1()
-        self.populate_cities()
-        self.area_admin_0.currentIndexChanged.connect(self.populate_admin_1)
-        self.area_admin_0.currentIndexChanged.connect(self.populate_cities)
-
-        # Handle saving to qsettings
-        self.area_admin_0.activated.connect(self.admin_0_changed)
-        self.secondLevel_area_admin_1.activated.connect(self.admin_1_changed)
-        self.secondLevel_city.activated.connect(self.admin_city_changed)
-        self.area_frompoint_point_x.textChanged.connect(self.point_x_changed)
-        self.area_frompoint_point_y.textChanged.connect(self.point_y_changed)
-        self.area_fromfile_file.textChanged.connect(self.file_changed)
-        self.groupBox_buffer.clicked.connect(self.buffer_changed)
-        self.buffer_size_km.valueChanged.connect(self.buffer_changed)
-
-        self.area_fromfile_browse.clicked.connect(self.open_vector_browse)
-        self.area_fromadmin.clicked.connect(self.area_type_toggle)
-        self.area_fromfile.clicked.connect(self.area_type_toggle)
-
-        self.radioButton_secondLevel_region.clicked.connect(self.radioButton_secondLevel_toggle)
-        self.radioButton_secondLevel_city.clicked.connect(self.radioButton_secondLevel_toggle)
-
-        icon = QIcon(QPixmap(':/plugins/LDMP/icons/map-marker.svg'))
-        self.area_frompoint_choose_point.setIcon(icon)
-        self.area_frompoint_choose_point.clicked.connect(self.point_chooser)
-        #TODO: Set range to only accept valid coordinates for current map coordinate system
-        self.area_frompoint_point_x.setValidator(QDoubleValidator())
-        #TODO: Set range to only accept valid coordinates for current map coordinate system
-        self.area_frompoint_point_y.setValidator(QDoubleValidator())
-        self.area_frompoint.clicked.connect(self.area_type_toggle)
-
-        # Setup point chooser
-        self.choose_point_tool = QgsMapToolEmitPoint(self.canvas)
-        self.choose_point_tool.canvasClicked.connect(self.set_point_coords)
-
-        proj_crs = QgsCoordinateReferenceSystem(self.canvas.mapSettings().destinationCrs().authid())
-        self.mQgsProjectionSelectionWidget.setCrs(QgsCoordinateReferenceSystem('epsg:4326'))
-
-    def showEvent(self, event):
-        super(AreaWidget, self).showEvent(event)
-
-        buffer_checked = QSettings().value("LDMP/AreaWidget/buffer_checked", False) == 'True'
-        area_from_option = QSettings().value("LDMP/AreaWidget/area_from_option", None)
-
-        if area_from_option == 'admin':
-            self.area_fromadmin.setChecked(True)
-        elif area_from_option == 'point':
-            self.area_frompoint.setChecked(True)
-        elif area_from_option == 'file':
-            self.area_fromfile.setChecked(True)
-        self.area_frompoint_point_x.setText(QSettings().value("LDMP/AreaWidget/area_frompoint_point_x", None))
-        self.area_frompoint_point_y.setText(QSettings().value("LDMP/AreaWidget/area_frompoint_point_y", None))
-        self.area_fromfile_file.setText(QSettings().value("LDMP/AreaWidget/area_fromfile_file", None))
-        self.area_type_toggle(False)
-
-        admin_0 = QSettings().value("LDMP/AreaWidget/area_admin_0", None)
-        if admin_0:
-            self.area_admin_0.setCurrentIndex(self.area_admin_0.findText(admin_0))
-            self.populate_admin_1()
-
-        area_from_option_secondLevel = QSettings().value("LDMP/AreaWidget/area_from_option_secondLevel", None)
-        if area_from_option_secondLevel == 'admin':
-            self.radioButton_secondLevel_region.setChecked(True)
-        elif area_from_option_secondLevel == 'city':
-            self.radioButton_secondLevel_city.setChecked(True)
-        self.radioButton_secondLevel_toggle(False)
-
-        secondLevel_area_admin_1 = QSettings().value("LDMP/AreaWidget/secondLevel_area_admin_1", None)
-        if secondLevel_area_admin_1:
-            self.secondLevel_area_admin_1.setCurrentIndex(self.secondLevel_area_admin_1.findText(secondLevel_area_admin_1))
-        secondLevel_city = QSettings().value("LDMP/AreaWidget/secondLevel_city", None)
-        if secondLevel_city:
-            self.populate_cities()
-            self.secondLevel_city.setCurrentIndex(self.secondLevel_city.findText(secondLevel_city))
-
-        buffer_size = QSettings().value("LDMP/AreaWidget/buffer_size", None)
-        if buffer_size:
-            self.buffer_size_km.setValue(float(buffer_size))
-        self.groupBox_buffer.setChecked(buffer_checked)
-
-    def admin_0_changed(self):
-        QSettings().setValue("LDMP/AreaWidget/area_admin_0", self.area_admin_0.currentText())
-
-    def admin_1_changed(self):
-        QSettings().setValue("LDMP/AreaWidget/secondLevel_area_admin_1", self.secondLevel_area_admin_1.currentText())
-        
-    def admin_city_changed(self):
-        QSettings().setValue("LDMP/AreaWidget/secondLevel_city", self.secondLevel_city.currentText())
-
-    def file_changed(self):
-        QSettings().setValue("LDMP/AreaWidget/area_fromfile_file", self.area_fromfile_file.text())
-
-    def point_x_changed(self):
-        QSettings().setValue("LDMP/AreaWidget/area_frompoint_point_x", self.area_frompoint_point_x.text())
-
-    def point_y_changed(self):
-        QSettings().setValue("LDMP/AreaWidget/area_frompoint_point_y", self.area_frompoint_point_y.text())
-
-    def buffer_changed(self):
-        QSettings().setValue("LDMP/AreaWidget/buffer_checked", str(self.groupBox_buffer.isChecked()))
-        QSettings().setValue("LDMP/AreaWidget/buffer_size", self.buffer_size_km.value())
-
-    def populate_cities(self):
-        self.secondLevel_city.clear()
-        adm0_a3 = self.admin_bounds_key[self.area_admin_0.currentText()]['code']
-        self.current_cities_key = {value['name_en']: key for key, value in self.cities[adm0_a3].items()}
-        self.secondLevel_city.addItems(sorted(self.current_cities_key.keys()))
-
-    def populate_admin_1(self):
-        self.secondLevel_area_admin_1.clear()
-        self.secondLevel_area_admin_1.addItems(['All regions'])
-        self.secondLevel_area_admin_1.addItems(sorted(self.admin_bounds_key[self.area_admin_0.currentText()]['admin1'].keys()))
-
-    def area_type_toggle(self, save=True):
-        if self.area_frompoint.isChecked():
-            if save: QSettings().setValue("LDMP/AreaWidget/area_from_option", 'point')
-            self.area_frompoint_point_x.setEnabled(True)
-            self.area_frompoint_point_y.setEnabled(True)
-            self.area_frompoint_choose_point.setEnabled(True)
-        else:
-            self.area_frompoint_point_x.setEnabled(False)
-            self.area_frompoint_point_y.setEnabled(False)
-            self.area_frompoint_choose_point.setEnabled(False)
-
-        if self.area_fromadmin.isChecked():
-            if save: QSettings().setValue("LDMP/AreaWidget/area_from_option", 'admin')
-            self.groupBox_first_level.setEnabled(True)
-            self.groupBox_second_level.setEnabled(True)
-        else:
-            self.groupBox_first_level.setEnabled(False)
-            self.groupBox_second_level.setEnabled(False)
-
-        if self.area_fromfile.isChecked():
-            if save: QSettings().setValue("LDMP/AreaWidget/area_from_option", 'file')
-            self.area_fromfile_file.setEnabled(True)
-            self.area_fromfile_browse.setEnabled(True)
-        else:
-            self.area_fromfile_file.setEnabled(False)
-            self.area_fromfile_browse.setEnabled(False)
-
-    def radioButton_secondLevel_toggle(self, save=True):
-        if self.radioButton_secondLevel_region.isChecked():
-            if save: QSettings().setValue("LDMP/AreaWidget/area_from_option_secondLevel", 'admin')
-            self.secondLevel_area_admin_1.setEnabled(True)
-            self.secondLevel_city.setEnabled(False)
-        else:
-            if save: QSettings().setValue("LDMP/AreaWidget/area_from_option_secondLevel", 'city')
-            self.secondLevel_area_admin_1.setEnabled(False)
-            self.secondLevel_city.setEnabled(True)
-
-    def point_chooser(self):
-        log("Choosing point from canvas...")
-        self.canvas.setMapTool(self.choose_point_tool)
-        self.window().hide()
-        QtWidgets.QMessageBox.critical(None, self.tr("Point chooser"), self.tr("Click the map to choose a point."))
-
-    def set_point_coords(self, point, button):
-        log("Set point coords")
-        #TODO: Show a messagebar while tool is active, and then remove the bar when a point is chosen.
-        self.point = point
-        # Disable the choose point tool
-        self.canvas.setMapTool(QgsMapToolPan(self.canvas))
-        # Don't reset_tab_on_show as it would lead to return to first tab after
-        # using the point chooser
-        self.window().reset_tab_on_showEvent = False
-        self.window().show()
-        self.window().reset_tab_on_showEvent = True
-        self.point = self.canvas.getCoordinateTransform().toMapCoordinates(self.canvas.mouseLastXY())
-        log("Chose point: {}, {}.".format(self.point.x(), self.point.y()))
-        self.area_frompoint_point_x.setText("{:.8f}".format(self.point.x()))
-        self.area_frompoint_point_y.setText("{:.8f}".format(self.point.y()))
-
-    def open_vector_browse(self):
-        initial_path = QSettings().value("LDMP/input_shapefile", None)
-        if not initial_path:
-            initial_path = QSettings().value("LDMP/input_shapefile_dir", None)
-        if not initial_path:
-            initial_path = str(Path.home())
-
-        vector_file, _ = QtWidgets.QFileDialog.getOpenFileName(self,
-                                                        self.tr('Select a file defining the area of interest'),
-                                                        initial_path,
-                                                        self.tr('Vector file (*.shp *.kml *.kmz *.geojson)'))
-        if vector_file:
-            if os.access(vector_file, os.R_OK):
-                QSettings().setValue("LDMP/input_shapefile", vector_file)
-                QSettings().setValue("LDMP/input_shapefile_dir", os.path.dirname(vector_file))
-                self.area_fromfile_file.setText(vector_file)
-                return True
-            else:
-                QtWidgets.QMessageBox.critical(None,
-                                               self.tr("Error"),
-                                               self.tr(u"Cannot read {}. Choose a different file.".format(vector_file)))
-                return False
-        else:
-            return False
-                
-
 class DlgCalculateBase(QtWidgets.QDialog):
     """Base class for individual indicator calculate dialogs"""
     firstShowEvent = pyqtSignal()
@@ -943,6 +729,17 @@ class DlgCalculateBase(QtWidgets.QDialog):
         self._firstShowEvent = True
         self.reset_tab_on_showEvent = True
         self._max_area = 5e7 # maximum size task the tool supports
+        self.settings = QgsSettings()
+
+        self.canvas = iface.mapCanvas()
+
+        self.admin_bounds_key = get_admin_bounds()
+        if not self.admin_bounds_key:
+            raise ValueError('Admin boundaries not available')
+
+        self.cities = get_cities()
+        if not self.cities:
+            raise ValueError('Cities list not available')
 
         self.firstShowEvent.connect(self.firstShow)
 
@@ -969,9 +766,6 @@ class DlgCalculateBase(QtWidgets.QDialog):
                 self.output_tab.set_output_summary(f)
 
     def firstShow(self):
-        self.area_tab = AreaWidget()
-        self.area_tab.setParent(self)
-        self.TabBox.addTab(self.area_tab, self.tr('Area'))
 
         if self._has_output:
             self.output_tab = CalculationOutputWidget(self.output_suffixes, self.get_subclass_name())
@@ -985,9 +779,6 @@ class DlgCalculateBase(QtWidgets.QDialog):
         # By default show the local or cloud option
         #self.options_tab.toggle_show_where_to_run(True)
         self.options_tab.toggle_show_where_to_run(False)
-
-        # By default hide the custom crs box
-        self.area_tab.groupBox_custom_crs.hide()
         
         self.button_calculate.clicked.connect(self.btn_calculate)
         self.button_prev.clicked.connect(self.tab_back)
@@ -1026,41 +817,50 @@ class DlgCalculateBase(QtWidgets.QDialog):
         self.close()
 
     def get_city_geojson(self):
-        adm0_a3 = self.area_tab.admin_bounds_key[self.area_tab.area_admin_0.currentText()]['code']
-        wof_id = self.area_tab.current_cities_key[self.area_tab.secondLevel_city.currentText()]
-        return (self.area_tab.cities[adm0_a3][wof_id]['geojson'])
+        adm0_a3 = self.admin_bounds_key[self.settings.value("trends_earth/AreaWidget/area_admin_0")]['code']
+        wof_id = self.settings.value("trends_earth/AreaWidget/current_cities_key")[
+            self.settings.value("trends_earth/AreaWidget/secondLevel_city")
+        ]
+        return (self.cities[adm0_a3][wof_id]['geojson'])
 
     def get_admin_poly_geojson(self):
-        adm0_a3 = self.area_tab.admin_bounds_key[self.area_tab.area_admin_0.currentText()]['code']
+        adm0_a3 = self.admin_bounds_key[self.settings.value("trends_earth/AreaWidget/area_admin_0")]['code']
         admin_polys = read_json(u'admin_bounds_polys_{}.json.gz'.format(adm0_a3), verify=False)
         if not admin_polys:
             return None
-        if not self.area_tab.secondLevel_area_admin_1.currentText() or self.area_tab.secondLevel_area_admin_1.currentText() == 'All regions':
+        if not self.settings.value("trends_earth/AreaWidget/secondLevel_area_admin_1") or \
+                self.settings.value("trends_earth/AreaWidget/secondLevel_area_admin_1") == 'All regions':
             return (admin_polys['geojson'])
         else:
-            admin_1_code = self.area_tab.admin_bounds_key[self.area_tab.area_admin_0.currentText()]['admin1'][self.area_tab.secondLevel_area_admin_1.currentText()]['code']
+            admin_1_code = self.admin_bounds_key[self.settings.value("trends_earth/AreaWidget/area_admin_0")][
+                'admin1'][self.settings.value("trends_earth/AreaWidget/secondLevel_area_admin_1")]['code']
             return (admin_polys['admin1'][admin_1_code]['geojson'])
 
     def btn_calculate(self):
-        if self.area_tab.groupBox_custom_crs.isChecked():
-            crs_dst = self.area_tab.mQgsProjectionSelectionWidget.crs()
+        if self.settings.value("trends_earth/AreaWidget/custom_crs_enabled"):
+            crs_dst = QgsCoordinateReferenceSystem(
+                self.settings.value("trends_earth/AreaWidget/custom_crs")
+            )
         else:
             crs_dst = QgsCoordinateReferenceSystem('epsg:4326')
 
         self.aoi = AOI(crs_dst)
 
-        if self.area_tab.area_fromadmin.isChecked():
-            if self.area_tab.radioButton_secondLevel_city.isChecked():
-                if not self.area_tab.groupBox_buffer.isChecked():
+        if self.settings.value("trends_earth/AreaWidget/area_from_option") == 'admin':
+            if self.settings.value("trends_earth/AreaWidget/secondLevel_city_button"):
+                if not self.settings.value("trends_earth/AreaWidget/groupBox_buffer"):
                     QtWidgets.QMessageBox.critical(None,tr_calculate.tr("Error"),
-                           tr_calculate.tr("You have chosen to run calculations for a city. You must select a buffer distance to define the calculation area when you are processing a city."))
+                           tr_calculate.tr("You have chosen to run calculations for a city."
+                                            "You must select a buffer distance to define the "
+                                           "calculation area when you are processing a city."))
                     return False
                 geojson = self.get_city_geojson()
                 self.aoi.update_from_geojson(geojson=geojson, 
-                                             wrap=self.area_tab.checkBox_custom_crs_wrap.isChecked(),
+                                             wrap=self.settings.value(
+                                                 "trends_earth/AreaWidget/checkBox_custom_crs_wrap"),
                                              datatype='point')
             else:
-                if not self.area_tab.area_admin_0.currentText():
+                if not self.settings.value("trends_earth/AreaWidget/area_admin_0"):
                     QtWidgets.QMessageBox.critical(None, self.tr("Error"),
                                                self.tr("Choose a first level administrative boundary."))
                     return False
@@ -1072,31 +872,38 @@ class DlgCalculateBase(QtWidgets.QDialog):
                                                self.tr("Unable to load administrative boundaries."))
                     return False
                 self.aoi.update_from_geojson(geojson=geojson, 
-                                             wrap=self.area_tab.checkBox_custom_crs_wrap.isChecked())
-        elif self.area_tab.area_fromfile.isChecked():
-            if not self.area_tab.area_fromfile_file.text():
+                                             wrap=self.settings.value(
+                                                 "trends_earth/AreaWidget/checkBox_custom_crs_wrap"))
+        elif self.settings.value("trends_earth/AreaWidget/area_from_option") == 'file':
+            if not self.settings.value("trends_earth/AreaWidget/area_fromfile_file"):
                 QtWidgets.QMessageBox.critical(None, self.tr("Error"),
                                            self.tr("Choose a file to define the area of interest."))
                 return False
-            if not os.access(self.area_tab.area_fromfile_file.text(), os.R_OK):
+            if not os.access(self.settings.value("trends_earth/AreaWidget/area_fromfile_file"), os.R_OK):
                 QtWidgets.QMessageBox.critical(None,
                                                self.tr("Error"),
-                                               self.tr("Unable to read {}.".format(self.area_tab.area_fromfile_file.text())))
+                                               self.tr("Unable to read {}.".format(
+                                                   self.settings.value("trends_earth/AreaWidget/area_fromfile_file")
+                                               )))
                 return False
-            self.aoi.update_from_file(f=self.area_tab.area_fromfile_file.text(),
-                                      wrap=self.area_tab.checkBox_custom_crs_wrap.isChecked())
-        elif self.area_tab.area_frompoint.isChecked():
+            self.aoi.update_from_file(f=self.settings.value("trends_earth/AreaWidget/area_fromfile_file"),
+                                      wrap=self.settings.value(
+                                                 "trends_earth/AreaWidget/checkBox_custom_crs_wrap"))
+        elif self.settings.value("trends_earth/AreaWidget/area_from_option") == 'point':
             # Area from point
-            if not self.area_tab.area_frompoint_point_x.text() or not self.area_tab.area_frompoint_point_y.text():
+            if not self.settings.value("trends_earth/AreaWidget/area_frompoint_point_x") or not \
+                    self.settings.value("trends_earth/AreaWidget/area_frompoint_point_y"):
                 QtWidgets.QMessageBox.critical(None, self.tr("Error"),
                                            self.tr("Choose a point to define the area of interest."))
                 return False
-            point = QgsPointXY(float(self.area_tab.area_frompoint_point_x.text()), float(self.area_tab.area_frompoint_point_y.text()))
-            crs_src = QgsCoordinateReferenceSystem(self.area_tab.canvas.mapSettings().destinationCrs().authid())
+            point = QgsPointXY(float(self.settings.value("trends_earth/AreaWidget/area_frompoint_point_x")),
+                               float(self.settings.value("trends_earth/AreaWidget/area_frompoint_point_y")))
+            crs_src = QgsCoordinateReferenceSystem(self.canvas.mapSettings().destinationCrs().authid())
             point = QgsCoordinateTransform(crs_src, crs_dst, QgsProject.instance()).transform(point)
             geojson = json.loads(QgsGeometry.fromPointXY(point).asJson())
             self.aoi.update_from_geojson(geojson=geojson, 
-                                         wrap=self.area_tab.checkBox_custom_crs_wrap.isChecked(),
+                                         wrap=self.settings.value(
+                                                 "trends_earth/AreaWidget/checkBox_custom_crs_wrap"),
                                          datatype='point')
         else:
             QtWidgets.QMessageBox.critical(None, self.tr("Error"),
@@ -1108,8 +915,8 @@ class DlgCalculateBase(QtWidgets.QDialog):
                                        self.tr("Unable to read area of interest."))
             return False
 
-        if self.area_tab.groupBox_buffer.isChecked():
-            ret = self.aoi.buffer(self.area_tab.buffer_size_km.value())
+        if self.settings.value("trends_earth/AreaWidget/groupBox_buffer"):
+            ret = self.aoi.buffer(self.settings.value("trends_earth/AreaWidget/buffer_size"))
             if not ret:
                 QtWidgets.QMessageBox.critical(None, self.tr("Error"),
                         self.tr("Error buffering polygon"))
@@ -1127,11 +934,12 @@ class DlgCalculateBase(QtWidgets.QDialog):
 
         # Limit processing area to be no greater than 10^7 sq km if using a 
         # custom shapefile
-        if not self.area_tab.area_fromadmin.isChecked():
+        if self.settings.value("trends_earth/AreaWidget/area_from_option") != 'admin':
             aoi_area = self.aoi.get_area() / (1000 * 1000)
             if aoi_area > self._max_area:
                 QtWidgets.QMessageBox.critical(None, self.tr("Error"),
-                        self.tr("The bounding box for the requested area (approximately {:.6n}) sq km is too large. Choose a smaller area to process.".format(aoi_area)))
+                        self.tr("The bounding box for the requested area (approximately {:.6n}) sq km "
+                                "is too large. Choose a smaller area to process.".format(aoi_area)))
                 return False
 
         if self._has_output:

--- a/LDMP/gui/DlgSettings.ui
+++ b/LDMP/gui/DlgSettings.ui
@@ -38,200 +38,12 @@
       <bool>true</bool>
      </property>
      <widget class="QWidget" name="scroll_area_content">
-      
-     <property name="font">
-      <font>
-       <weight>50</weight>
-       <bold>false</bold>
-      </font>
-     </property>
-     <property name="title">
-      <string>Trends.Earth remote server</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <widget class="QgsAuthConfigSelect" name="authConfigSelect_authentication">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>30</height>
-           </size>
-          </property>
-          <property name="font">
-           <font>
-            <weight>50</weight>
-            <bold>false</bold>
-           </font>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pushButton_login">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="font">
-           <font>
-            <weight>50</weight>
-            <bold>false</bold>
-           </font>
-          </property>
-          <property name="text">
-           <string>Test connection</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
-        <item>
-         <widget class="QPushButton" name="pushButton_register">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>80</width>
-            <height>30</height>
-           </size>
-          </property>
-          <property name="font">
-           <font>
-            <weight>50</weight>
-            <bold>false</bold>
-           </font>
-          </property>
-          <property name="text">
-           <string>Register</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pushButton_update_profile">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>120</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="font">
-           <font>
-            <weight>50</weight>
-            <bold>false</bold>
-           </font>
-          </property>
-          <property name="text">
-           <string>Update profile</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pushButton_forgot_pwd">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>120</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Reset password</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pushButton_delete_user">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>100</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Delete user</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_advanced">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="font">
-      <font>
-       <weight>50</weight>
-       <bold>false</bold>
-      </font>
-     </property>
-     <property name="title">
-      <string>Advanced</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_advanced"/>
       <property name="geometry">
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>550</width>
-        <height>792</height>
+        <width>593</width>
+        <height>640</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -429,7 +241,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="groupBox_3">
+        <widget class="QGroupBox" name="groupBox_advanced">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
            <horstretch>0</horstretch>
@@ -443,35 +255,9 @@
           </font>
          </property>
          <property name="title">
-          <string>Advanced users</string>
+          <string>Advanced</string>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_3">
-          <item>
-           <widget class="QPushButton" name="pushButton_advanced">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>30</height>
-             </size>
-            </property>
-            <property name="font">
-             <font>
-              <weight>50</weight>
-              <bold>false</bold>
-             </font>
-            </property>
-            <property name="text">
-             <string>Edit advanced options</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
+         <layout class="QVBoxLayout" name="verticalLayout_advanced"/>
         </widget>
        </item>
        <item>

--- a/LDMP/gui/DlgSettings.ui
+++ b/LDMP/gui/DlgSettings.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>611</width>
-    <height>689</height>
+    <width>608</width>
+    <height>887</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -29,6 +29,12 @@
    <string>Settings</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_8">
+   <property name="leftMargin">
+    <number>9</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
    <item>
     <widget class="QgsScrollArea" name="scroll_area">
      <property name="frameShape">
@@ -42,11 +48,20 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>593</width>
-        <height>640</height>
+        <width>599</width>
+        <height>838</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_6">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
        <item>
         <widget class="QFrame" name="region_of_interest">
          <property name="frameShape">

--- a/LDMP/gui/DlgSettings.ui
+++ b/LDMP/gui/DlgSettings.ui
@@ -30,18 +30,12 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
-    <widget class="QGroupBox" name="groupBox">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+    <widget class="QgsScrollArea" name="scroll_area">
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
      </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>0</height>
-      </size>
+     <property name="widgetResizable">
+      <bool>true</bool>
      </property>
      <property name="font">
       <font>
@@ -261,6 +255,8 @@
   <customwidget>
    <class>QgsAuthConfigSelect</class>
    <extends>QWidget</extends>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
    <header>qgis.gui</header>
   </customwidget>
  </customwidgets>

--- a/LDMP/gui/DlgSettings.ui
+++ b/LDMP/gui/DlgSettings.ui
@@ -28,7 +28,7 @@
   <property name="windowTitle">
    <string>Settings</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
+  <layout class="QVBoxLayout" name="verticalLayout_8">
    <item>
     <widget class="QgsScrollArea" name="scroll_area">
      <property name="frameShape">
@@ -37,6 +37,8 @@
      <property name="widgetResizable">
       <bool>true</bool>
      </property>
+     <widget class="QWidget" name="scroll_area_content">
+      
      <property name="font">
       <font>
        <weight>50</weight>
@@ -224,28 +226,281 @@
       <string>Advanced</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_advanced"/>
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>550</width>
+        <height>792</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_6">
+       <item>
+        <widget class="QFrame" name="region_of_interest">
+         <property name="frameShape">
+          <enum>QFrame::NoFrame</enum>
+         </property>
+         <property name="frameShadow">
+          <enum>QFrame::Raised</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="font">
+          <font>
+           <weight>50</weight>
+           <bold>false</bold>
+          </font>
+         </property>
+         <property name="title">
+          <string>Trends.Earth remote server</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout">
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout">
+            <item>
+             <widget class="QgsAuthConfigSelect" name="authConfigSelect_authentication">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>30</height>
+               </size>
+              </property>
+              <property name="font">
+               <font>
+                <weight>50</weight>
+                <bold>false</bold>
+               </font>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="pushButton_login">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="font">
+               <font>
+                <weight>50</weight>
+                <bold>false</bold>
+               </font>
+              </property>
+              <property name="text">
+               <string>Test connection</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_2">
+            <item>
+             <widget class="QPushButton" name="pushButton_register">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>80</width>
+                <height>30</height>
+               </size>
+              </property>
+              <property name="font">
+               <font>
+                <weight>50</weight>
+                <bold>false</bold>
+               </font>
+              </property>
+              <property name="text">
+               <string>Register</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="pushButton_update_profile">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>120</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="font">
+               <font>
+                <weight>50</weight>
+                <bold>false</bold>
+               </font>
+              </property>
+              <property name="text">
+               <string>Update profile</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="pushButton_forgot_pwd">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>120</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>Reset password</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QPushButton" name="pushButton_delete_user">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>100</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>Delete user</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBox_3">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="font">
+          <font>
+           <weight>50</weight>
+           <bold>false</bold>
+          </font>
+         </property>
+         <property name="title">
+          <string>Advanced users</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_3">
+          <item>
+           <widget class="QPushButton" name="pushButton_advanced">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>30</height>
+             </size>
+            </property>
+            <property name="font">
+             <font>
+              <weight>50</weight>
+              <bold>false</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Edit advanced options</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
    <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>39</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
     <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
@@ -255,44 +510,15 @@
   <customwidget>
    <class>QgsAuthConfigSelect</class>
    <extends>QWidget</extends>
+   <header>qgis.gui</header>
+  </customwidget>
+  <customwidget>
    <class>QgsScrollArea</class>
    <extends>QScrollArea</extends>
    <header>qgis.gui</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>
- <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>DlgSettings</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>298</x>
-     <y>774</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>298</x>
-     <y>397</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>DlgSettings</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>298</x>
-     <y>774</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>298</x>
-     <y>397</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/LDMP/gui/DlgSettings.ui
+++ b/LDMP/gui/DlgSettings.ui
@@ -247,14 +247,11 @@
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
@@ -268,5 +265,38 @@
   </customwidget>
  </customwidgets>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>DlgSettings</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>298</x>
+     <y>774</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>298</x>
+     <y>397</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>DlgSettings</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>298</x>
+     <y>774</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>298</x>
+     <y>397</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/LDMP/gui/WidgetSelectArea.ui
+++ b/LDMP/gui/WidgetSelectArea.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>532</width>
-    <height>803</height>
+    <width>524</width>
+    <height>597</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -29,25 +29,37 @@
    <property name="rightMargin">
     <number>0</number>
    </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
-    <widget class="QgsCollapsibleGroupBox" name="mGroupBox">
+    <widget class="QGroupBox" name="area_groupbox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="title">
       <string>Algorithm region of interest</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <property name="spacing">
-       <number>0</number>
-      </property>
+     <layout class="QGridLayout" name="area_groupbox_gridLayout">
       <property name="leftMargin">
-       <number>2</number>
+       <number>9</number>
       </property>
       <property name="topMargin">
        <number>0</number>
       </property>
-      <property name="bottomMargin">
+      <property name="rightMargin">
        <number>0</number>
       </property>
-      <item>
+      <property name="bottomMargin">
+       <number>9</number>
+      </property>
+      <property name="spacing">
+       <number>6</number>
+      </property>
+      <item row="0" column="0">
        <widget class="QRadioButton" name="area_fromadmin">
         <property name="text">
          <string>Country / Region</string>
@@ -60,7 +72,17 @@
         </attribute>
        </widget>
       </item>
-      <item>
+      <item row="11" column="0">
+       <widget class="QRadioButton" name="area_frompoint">
+        <property name="text">
+         <string>Point</string>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">area_radio_buttonGroup</string>
+        </attribute>
+       </widget>
+      </item>
+      <item row="1" column="0">
        <widget class="QFrame" name="frame_country_region">
         <property name="frameShape">
          <enum>QFrame::NoFrame</enum>
@@ -68,7 +90,7 @@
         <property name="frameShadow">
          <enum>QFrame::Plain</enum>
         </property>
-        <layout class="QVBoxLayout" name="verticalLayout_4">
+        <layout class="QVBoxLayout" name="verticalLayout_2">
          <item>
           <widget class="QLabel" name="first_level_label">
            <property name="text">
@@ -93,89 +115,109 @@
           </widget>
          </item>
          <item>
-          <widget class="QGroupBox" name="groupBox_second_level">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
+          <widget class="QFrame" name="second_level">
+           <property name="frameShape">
+            <enum>QFrame::NoFrame</enum>
            </property>
-           <property name="title">
-            <string>Second level</string>
+           <property name="frameShadow">
+            <enum>QFrame::Raised</enum>
            </property>
-           <layout class="QGridLayout" name="gridLayout_3">
-            <item row="3" column="1">
-             <widget class="QComboBox" name="secondLevel_city">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>30</height>
-               </size>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="0">
-             <widget class="QRadioButton" name="radioButton_secondLevel_city">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>30</height>
-               </size>
-              </property>
+           <layout class="QVBoxLayout" name="verticalLayout_3">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="second_level_label">
               <property name="text">
-               <string>City:</string>
+               <string>Second level</string>
               </property>
              </widget>
             </item>
-            <item row="2" column="0">
-             <widget class="QRadioButton" name="radioButton_secondLevel_region">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>30</height>
-               </size>
-              </property>
-              <property name="text">
-               <string>Region:</string>
-              </property>
-              <property name="checked">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1">
-             <widget class="QComboBox" name="secondLevel_area_admin_1">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>30</height>
-               </size>
-              </property>
-             </widget>
+            <item>
+             <layout class="QGridLayout" name="gridLayout">
+              <item row="0" column="1">
+               <widget class="QComboBox" name="secondLevel_area_admin_1">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>0</width>
+                  <height>30</height>
+                 </size>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QRadioButton" name="radioButton_secondLevel_city">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>0</width>
+                  <height>30</height>
+                 </size>
+                </property>
+                <property name="text">
+                 <string>City:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QComboBox" name="secondLevel_city">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>0</width>
+                  <height>30</height>
+                 </size>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="0">
+               <widget class="QRadioButton" name="radioButton_secondLevel_region">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>0</width>
+                  <height>30</height>
+                 </size>
+                </property>
+                <property name="text">
+                 <string>Region:</string>
+                </property>
+                <property name="checked">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+             </layout>
             </item>
            </layout>
           </widget>
@@ -202,121 +244,7 @@
         </layout>
        </widget>
       </item>
-      <item>
-       <widget class="QRadioButton" name="area_frompoint">
-        <property name="text">
-         <string>Point</string>
-        </property>
-        <attribute name="buttonGroup">
-         <string notr="true">area_radio_buttonGroup</string>
-        </attribute>
-       </widget>
-      </item>
-      <item>
-       <widget class="QFrame" name="frame_area_frompoint">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="frameShape">
-         <enum>QFrame::NoFrame</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Plain</enum>
-        </property>
-        <layout class="QHBoxLayout" name="horizontalLayout_4">
-         <item>
-          <widget class="QLabel" name="area_frompoint_label_x">
-           <property name="font">
-            <font>
-             <weight>50</weight>
-             <bold>false</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>x:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLineEdit" name="area_frompoint_point_x">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>30</height>
-            </size>
-           </property>
-           <property name="inputMethodHints">
-            <set>Qt::ImhPreferNumbers</set>
-           </property>
-           <property name="placeholderText">
-            <string>Choose a point...</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="area_frompoint_label_y">
-           <property name="font">
-            <font>
-             <weight>50</weight>
-             <bold>false</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>y:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLineEdit" name="area_frompoint_point_y">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>30</height>
-            </size>
-           </property>
-           <property name="placeholderText">
-            <string>Choose a point...</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="area_frompoint_choose_point">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>30</height>
-            </size>
-           </property>
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item>
+      <item row="13" column="0">
        <widget class="QRadioButton" name="area_fromfile">
         <property name="text">
          <string>Area from file</string>
@@ -326,7 +254,14 @@
         </attribute>
        </widget>
       </item>
-      <item>
+      <item row="15" column="0">
+       <widget class="QCheckBox" name="checkbox_buffer">
+        <property name="text">
+         <string>Apply a buffer to the chosen area</string>
+        </property>
+       </widget>
+      </item>
+      <item row="14" column="0">
        <widget class="QFrame" name="frame_area_fromfile">
         <property name="frameShape">
          <enum>QFrame::NoFrame</enum>
@@ -335,9 +270,6 @@
          <enum>QFrame::Plain</enum>
         </property>
         <layout class="QHBoxLayout" name="horizontalLayout_3">
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
          <item>
           <widget class="QLineEdit" name="area_fromfile_file">
            <property name="enabled">
@@ -394,26 +326,130 @@
         </layout>
        </widget>
       </item>
-      <item>
-       <widget class="QGroupBox" name="groupBox_buffer">
+      <item row="12" column="0" colspan="2">
+       <widget class="QFrame" name="frame_area_frompoint">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-        <property name="title">
-         <string>Apply a buffer to the chosen area</string>
+        <property name="frameShape">
+         <enum>QFrame::NoFrame</enum>
         </property>
-        <property name="checkable">
-         <bool>true</bool>
+        <property name="frameShadow">
+         <enum>QFrame::Plain</enum>
         </property>
-        <property name="checked">
+        <layout class="QHBoxLayout" name="horizontalLayout_4">
+         <item>
+          <widget class="QLabel" name="area_frompoint_label_x">
+           <property name="font">
+            <font>
+             <weight>50</weight>
+             <bold>false</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>longitude:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="area_frompoint_point_x">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>30</height>
+            </size>
+           </property>
+           <property name="inputMethodHints">
+            <set>Qt::ImhPreferNumbers</set>
+           </property>
+           <property name="placeholderText">
+            <string>Choose a point...</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="area_frompoint_label_y">
+           <property name="font">
+            <font>
+             <weight>50</weight>
+             <bold>false</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>latitude:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="area_frompoint_point_y">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>30</height>
+            </size>
+           </property>
+           <property name="placeholderText">
+            <string>Choose a point...</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="area_frompoint_choose_point">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>30</height>
+            </size>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="16" column="0">
+       <widget class="QFrame" name="frame">
+        <property name="enabled">
          <bool>false</bool>
         </property>
-        <layout class="QGridLayout" name="gridLayout_2">
+        <property name="maximumSize">
+         <size>
+          <width>450</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::NoFrame</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Plain</enum>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout">
          <property name="leftMargin">
-          <number>0</number>
+          <number>9</number>
          </property>
          <property name="topMargin">
           <number>0</number>
@@ -424,81 +460,63 @@
          <property name="bottomMargin">
           <number>0</number>
          </property>
-         <item row="0" column="0">
-          <widget class="QFrame" name="frame">
+         <item>
+          <widget class="QLabel" name="label">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>30</height>
+            </size>
+           </property>
            <property name="maximumSize">
             <size>
-             <width>450</width>
+             <width>250</width>
              <height>16777215</height>
             </size>
            </property>
-           <property name="frameShape">
-            <enum>QFrame::NoFrame</enum>
+           <property name="text">
+            <string>Buffer size (kilometers):</string>
            </property>
-           <property name="frameShadow">
-            <enum>QFrame::Plain</enum>
+          </widget>
+         </item>
+         <item>
+          <widget class="QDoubleSpinBox" name="buffer_size_km">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
            </property>
-           <layout class="QHBoxLayout" name="horizontalLayout">
-            <item>
-             <widget class="QLabel" name="label">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>30</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>250</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="text">
-               <string>Buffer size (kilometers):</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QDoubleSpinBox" name="buffer_size_km">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>30</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>200</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="decimals">
-               <number>1</number>
-              </property>
-              <property name="minimum">
-               <double>0.100000000000000</double>
-              </property>
-              <property name="maximum">
-               <double>1000.000000000000000</double>
-              </property>
-              <property name="value">
-               <double>10.000000000000000</double>
-              </property>
-             </widget>
-            </item>
-           </layout>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>30</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>200</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="decimals">
+            <number>1</number>
+           </property>
+           <property name="minimum">
+            <double>0.100000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>1000.000000000000000</double>
+           </property>
+           <property name="value">
+            <double>10.000000000000000</double>
+           </property>
           </widget>
          </item>
         </layout>
@@ -507,31 +525,27 @@
      </layout>
     </widget>
    </item>
-   <item>
-    <spacer name="verticalSpacer_4">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>0</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
   </layout>
  </widget>
- <customwidgets>
-  <customwidget>
-   <class>QgsCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>qgis.gui</header>
-   <container>1</container>
-  </customwidget>
- </customwidgets>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>checkbox_buffer</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>frame</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>119</x>
+     <y>547</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>16</x>
+     <y>566</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
  <buttongroups>
   <buttongroup name="area_radio_buttonGroup"/>
  </buttongroups>

--- a/LDMP/gui/WidgetSelectArea.ui
+++ b/LDMP/gui/WidgetSelectArea.ui
@@ -526,7 +526,7 @@
   <customwidget>
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
+   <header>qgis.gui</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/LDMP/gui/WidgetSelectArea.ui
+++ b/LDMP/gui/WidgetSelectArea.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>492</width>
-    <height>843</height>
+    <width>532</width>
+    <height>803</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -30,108 +30,37 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QGroupBox" name="area_groupbox">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
+    <widget class="QgsCollapsibleGroupBox" name="mGroupBox">
      <property name="title">
       <string>Algorithm region of interest</string>
      </property>
-     <layout class="QGridLayout" name="area_groupbox_gridLayout">
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <property name="spacing">
+       <number>0</number>
+      </property>
       <property name="leftMargin">
        <number>2</number>
       </property>
       <property name="topMargin">
        <number>0</number>
       </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
       <property name="bottomMargin">
        <number>0</number>
       </property>
-      <item row="14" column="0">
-       <widget class="QFrame" name="frame_area_fromfile">
-        <property name="frameShape">
-         <enum>QFrame::NoFrame</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Plain</enum>
-        </property>
-        <layout class="QHBoxLayout" name="horizontalLayout_3">
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QLineEdit" name="area_fromfile_file">
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>120</width>
-             <height>30</height>
-            </size>
-           </property>
-           <property name="readOnly">
-            <bool>true</bool>
-           </property>
-           <property name="placeholderText">
-            <string>Click &quot;Browse&quot; to choose a file...</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="area_fromfile_browse">
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>30</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>80</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>Browse</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="13" column="0">
-       <widget class="QRadioButton" name="area_fromfile">
+      <item>
+       <widget class="QRadioButton" name="area_fromadmin">
         <property name="text">
-         <string>Area from file</string>
+         <string>Country / Region</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
         </property>
         <attribute name="buttonGroup">
          <string notr="true">area_radio_buttonGroup</string>
         </attribute>
        </widget>
       </item>
-      <item row="1" column="0">
+      <item>
        <widget class="QFrame" name="frame_country_region">
         <property name="frameShape">
          <enum>QFrame::NoFrame</enum>
@@ -140,9 +69,6 @@
          <enum>QFrame::Plain</enum>
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_4">
-         <property name="leftMargin">
-          <number>9</number>
-         </property>
          <item>
           <widget class="QLabel" name="first_level_label">
            <property name="text">
@@ -276,7 +202,7 @@
         </layout>
        </widget>
       </item>
-      <item row="11" column="0">
+      <item>
        <widget class="QRadioButton" name="area_frompoint">
         <property name="text">
          <string>Point</string>
@@ -286,7 +212,7 @@
         </attribute>
        </widget>
       </item>
-      <item row="12" column="0" colspan="2">
+      <item>
        <widget class="QFrame" name="frame_area_frompoint">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -390,20 +316,85 @@
         </layout>
        </widget>
       </item>
-      <item row="0" column="0">
-       <widget class="QRadioButton" name="area_fromadmin">
+      <item>
+       <widget class="QRadioButton" name="area_fromfile">
         <property name="text">
-         <string>Country / Region</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
+         <string>Area from file</string>
         </property>
         <attribute name="buttonGroup">
          <string notr="true">area_radio_buttonGroup</string>
         </attribute>
        </widget>
       </item>
-      <item row="15" column="0">
+      <item>
+       <widget class="QFrame" name="frame_area_fromfile">
+        <property name="frameShape">
+         <enum>QFrame::NoFrame</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Plain</enum>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLineEdit" name="area_fromfile_file">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>120</width>
+             <height>30</height>
+            </size>
+           </property>
+           <property name="readOnly">
+            <bool>true</bool>
+           </property>
+           <property name="placeholderText">
+            <string>Click &quot;Browse&quot; to choose a file...</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="area_fromfile_browse">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>30</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>80</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Browse</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
        <widget class="QGroupBox" name="groupBox_buffer">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
@@ -517,53 +508,6 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox_custom_crs">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="title">
-      <string>Use custom coordinate reference system (CRS) for output</string>
-     </property>
-     <property name="checkable">
-      <bool>true</bool>
-     </property>
-     <property name="checked">
-      <bool>false</bool>
-     </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="1" column="0">
-       <widget class="QCheckBox" name="checkBox_custom_crs_wrap">
-        <property name="maximumSize">
-         <size>
-          <width>15</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QLabel" name="label_custom_crs_wrap">
-        <property name="text">
-         <string>Wrap longitudes across central meridian before projecting into output CRS (recommended for countries like Russia and Fiji if you are using an output coordinate reference system that is continuous across the 180th meridian)</string>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0" colspan="2">
-       <widget class="QgsProjectionSelectionWidget" name="mQgsProjectionSelectionWidget"/>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
     <spacer name="verticalSpacer_4">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -580,9 +524,10 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsProjectionSelectionWidget</class>
-   <extends>QWidget</extends>
-   <header>qgis.gui</header>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/LDMP/gui/WidgetSelectArea.ui
+++ b/LDMP/gui/WidgetSelectArea.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>492</width>
-    <height>579</height>
+    <height>843</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -20,6 +20,15 @@
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
    <item>
     <widget class="QGroupBox" name="area_groupbox">
      <property name="sizePolicy">
@@ -29,23 +38,248 @@
       </sizepolicy>
      </property>
      <property name="title">
-      <string>Area to run calculations for</string>
+      <string>Algorithm region of interest</string>
      </property>
      <layout class="QGridLayout" name="area_groupbox_gridLayout">
-      <item row="11" column="0">
-       <widget class="QRadioButton" name="area_frompoint">
-        <property name="text">
-         <string>Point</string>
+      <property name="leftMargin">
+       <number>2</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item row="14" column="0">
+       <widget class="QFrame" name="frame_area_fromfile">
+        <property name="frameShape">
+         <enum>QFrame::NoFrame</enum>
         </property>
-        <attribute name="buttonGroup">
-         <string notr="true">area_radio_buttonGroup</string>
-        </attribute>
+        <property name="frameShadow">
+         <enum>QFrame::Plain</enum>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLineEdit" name="area_fromfile_file">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>120</width>
+             <height>30</height>
+            </size>
+           </property>
+           <property name="readOnly">
+            <bool>true</bool>
+           </property>
+           <property name="placeholderText">
+            <string>Click &quot;Browse&quot; to choose a file...</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="area_fromfile_browse">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>30</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>80</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Browse</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
       <item row="13" column="0">
        <widget class="QRadioButton" name="area_fromfile">
         <property name="text">
          <string>Area from file</string>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">area_radio_buttonGroup</string>
+        </attribute>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QFrame" name="frame_country_region">
+        <property name="frameShape">
+         <enum>QFrame::NoFrame</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Plain</enum>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_4">
+         <property name="leftMargin">
+          <number>9</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="first_level_label">
+           <property name="text">
+            <string>First level</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="area_admin_0">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>30</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QGroupBox" name="groupBox_second_level">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="title">
+            <string>Second level</string>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_3">
+            <item row="3" column="1">
+             <widget class="QComboBox" name="secondLevel_city">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>30</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <widget class="QRadioButton" name="radioButton_secondLevel_city">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>30</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>City:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QRadioButton" name="radioButton_secondLevel_region">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>30</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>Region:</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QComboBox" name="secondLevel_area_admin_1">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>30</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_disclaimer">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Disclaimer: The provided boundaries are from &lt;a href=&quot;http://www.naturalearthdata.com/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Natural Earth&lt;/span&gt;&lt;/a&gt;, and are in the &lt;a href=&quot;http://creativecommons.org/publicdomain&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;public domain&lt;/span&gt;&lt;/a&gt;. The boundaries and names used, and the designations used, in Trends.Earth do not imply official endorsement or acceptance by Conservation International Foundation, or by its partner organizations and contributors.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+           <property name="openExternalLinks">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="11" column="0">
+       <widget class="QRadioButton" name="area_frompoint">
+        <property name="text">
+         <string>Point</string>
         </property>
         <attribute name="buttonGroup">
          <string notr="true">area_radio_buttonGroup</string>
@@ -169,96 +403,55 @@
         </attribute>
        </widget>
       </item>
-      <item row="14" column="0">
-       <widget class="QFrame" name="frame_area_fromfile">
-        <property name="frameShape">
-         <enum>QFrame::NoFrame</enum>
+      <item row="15" column="0">
+       <widget class="QGroupBox" name="groupBox_buffer">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
         </property>
-        <property name="frameShadow">
-         <enum>QFrame::Plain</enum>
+        <property name="title">
+         <string>Apply a buffer to the chosen area</string>
         </property>
-        <layout class="QHBoxLayout" name="horizontalLayout_3">
-         <item>
-          <widget class="QLineEdit" name="area_fromfile_file">
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>120</width>
-             <height>30</height>
-            </size>
-           </property>
-           <property name="readOnly">
-            <bool>true</bool>
-           </property>
-           <property name="placeholderText">
-            <string>Click &quot;Browse&quot; to choose a file...</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="area_fromfile_browse">
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>30</height>
-            </size>
-           </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_2">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item row="0" column="0">
+          <widget class="QFrame" name="frame">
            <property name="maximumSize">
             <size>
-             <width>80</width>
+             <width>450</width>
              <height>16777215</height>
             </size>
            </property>
-           <property name="text">
-            <string>Browse</string>
+           <property name="frameShape">
+            <enum>QFrame::NoFrame</enum>
            </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QFrame" name="frame_country_region">
-        <property name="frameShape">
-         <enum>QFrame::NoFrame</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Plain</enum>
-        </property>
-        <layout class="QVBoxLayout" name="verticalLayout_4">
-         <item>
-          <widget class="QGroupBox" name="groupBox_first_level">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
+           <property name="frameShadow">
+            <enum>QFrame::Plain</enum>
            </property>
-           <property name="title">
-            <string>First level</string>
-           </property>
-           <layout class="QVBoxLayout" name="verticalLayout_2">
+           <layout class="QHBoxLayout" name="horizontalLayout">
             <item>
-             <widget class="QComboBox" name="area_admin_0">
+             <widget class="QLabel" name="label">
               <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
                 <horstretch>0</horstretch>
                 <verstretch>0</verstretch>
                </sizepolicy>
@@ -268,215 +461,53 @@
                 <width>0</width>
                 <height>30</height>
                </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>250</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>Buffer size (kilometers):</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QDoubleSpinBox" name="buffer_size_km">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>30</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>200</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="decimals">
+               <number>1</number>
+              </property>
+              <property name="minimum">
+               <double>0.100000000000000</double>
+              </property>
+              <property name="maximum">
+               <double>1000.000000000000000</double>
+              </property>
+              <property name="value">
+               <double>10.000000000000000</double>
               </property>
              </widget>
             </item>
            </layout>
-          </widget>
-         </item>
-         <item>
-          <widget class="QGroupBox" name="groupBox_second_level">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="title">
-            <string>Second level</string>
-           </property>
-           <layout class="QGridLayout" name="gridLayout_3">
-            <item row="3" column="1">
-             <widget class="QComboBox" name="secondLevel_city">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>30</height>
-               </size>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="0">
-             <widget class="QRadioButton" name="radioButton_secondLevel_city">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>30</height>
-               </size>
-              </property>
-              <property name="text">
-               <string>City:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="QRadioButton" name="radioButton_secondLevel_region">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>30</height>
-               </size>
-              </property>
-              <property name="text">
-               <string>Region:</string>
-              </property>
-              <property name="checked">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1">
-             <widget class="QComboBox" name="secondLevel_area_admin_1">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>30</height>
-               </size>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="label_disclaimer">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Disclaimer: The provided boundaries are from &lt;a href=&quot;http://www.naturalearthdata.com/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Natural Earth&lt;/span&gt;&lt;/a&gt;, and are in the &lt;a href=&quot;http://creativecommons.org/publicdomain&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;public domain&lt;/span&gt;&lt;/a&gt;. The boundaries and names used, and the designations used, in Trends.Earth do not imply official endorsement or acceptance by Conservation International Foundation, or by its partner organizations and contributors.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-           <property name="wordWrap">
-            <bool>true</bool>
-           </property>
-           <property name="openExternalLinks">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_buffer">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="title">
-      <string>Apply a buffer to the chosen area</string>
-     </property>
-     <property name="checkable">
-      <bool>true</bool>
-     </property>
-     <property name="checked">
-      <bool>false</bool>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="0" column="0">
-       <widget class="QFrame" name="frame">
-        <property name="maximumSize">
-         <size>
-          <width>450</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="frameShape">
-         <enum>QFrame::NoFrame</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Plain</enum>
-        </property>
-        <layout class="QHBoxLayout" name="horizontalLayout">
-         <item>
-          <widget class="QLabel" name="label">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>30</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>250</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>Buffer size (kilometers):</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QDoubleSpinBox" name="buffer_size_km">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>30</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>200</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="decimals">
-            <number>1</number>
-           </property>
-           <property name="minimum">
-            <double>0.100000000000000</double>
-           </property>
-           <property name="maximum">
-            <double>1000.000000000000000</double>
-           </property>
-           <property name="value">
-            <double>10.000000000000000</double>
-           </property>
           </widget>
          </item>
         </layout>

--- a/LDMP/settings.py
+++ b/LDMP/settings.py
@@ -107,17 +107,12 @@ class DlgSettings(QtWidgets.QDialog, Ui_DlgSettings):
         self.buttonBox.accepted.connect(self.close)
         self.settings = QgsSettings()
 
-        scroll_container = QtWidgets.QWidget()
         self.area_widget = AreaWidget()
         layout = QtWidgets.QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(self.area_widget)
 
-        scroll_container.setLayout(layout)
-
-        self.scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOn)
-        self.scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
-        self.scroll_area.setWidgetResizable(True)
-        self.scroll_area.setWidget(scroll_container)
+        self.region_of_interest.setLayout(layout)
 
         # load gui default value from settings
         self.reloadAuthConfigurations()
@@ -268,7 +263,7 @@ class AreaWidget(QtWidgets.QWidget, Ui_WidgetSelectArea):
 
     def load_settings(self):
 
-        buffer_checked = self.settings.value("trends_earth/region_of_interest/buffer_checked", False)
+        buffer_checked = self.settings.value("trends_earth/region_of_interest/buffer_checked", False) == 'True'
         area_from_option = self.settings.value("trends_earth/region_of_interest/chosen_method", None)
 
         if area_from_option == 'country_region' or \
@@ -327,8 +322,10 @@ class AreaWidget(QtWidgets.QWidget, Ui_WidgetSelectArea):
         self.area_frompoint_point_y.setEnabled(self.area_frompoint.isChecked())
         self.area_frompoint_choose_point.setEnabled(self.area_frompoint.isChecked())
 
-        self.groupBox_first_level.setEnabled(self.area_fromadmin.isChecked())
+        self.area_admin_0.setEnabled(self.area_fromadmin.isChecked())
+        self.first_level_label.setEnabled(self.area_fromadmin.isChecked())
         self.groupBox_second_level.setEnabled(self.area_fromadmin.isChecked())
+        self.label_disclaimer.setEnabled(self.area_fromadmin.isChecked())
 
         self.area_fromfile_file.setEnabled(self.area_fromfile.isChecked())
         self.area_fromfile_browse.setEnabled(self.area_fromfile.isChecked())

--- a/LDMP/settings.py
+++ b/LDMP/settings.py
@@ -24,9 +24,9 @@ from qgis.PyQt import QtWidgets
 from qgis.PyQt.QtGui import QIcon, QPixmap, QDoubleValidator
 
 from qgis.core import QgsSettings
-from qgis.core import QgsCoordinateReferenceSystem
 from qgis.gui import QgsMapToolEmitPoint, QgsMapToolPan
 
+from qgis.utils import iface
 
 from qgis.core import QgsApplication
 
@@ -58,8 +58,6 @@ from LDMP.api import (
 from LDMP import log
 from LDMP.download import download_files, get_admin_bounds, read_json, get_cities
 from LDMP.message_bar import MessageBar
-
-settings = QSettings()
 
 settings = QSettings()
 
@@ -253,11 +251,6 @@ class AreaWidget(QtWidgets.QWidget, Ui_WidgetSelectArea):
         # Setup point chooser
         self.choose_point_tool = QgsMapToolEmitPoint(self.canvas)
         self.choose_point_tool.canvasClicked.connect(self.set_point_coords)
-
-        proj_crs = QgsCoordinateReferenceSystem(self.canvas.mapSettings().destinationCrs().authid())
-        self.mQgsProjectionSelectionWidget.setCrs(QgsCoordinateReferenceSystem('epsg:4326'))
-
-        self.groupBox_custom_crs.hide()
 
         self.load_settings()
 
@@ -456,10 +449,6 @@ class AreaWidget(QtWidgets.QWidget, Ui_WidgetSelectArea):
             self.settings.setValue("trends_earth/region_of_interest/current_cities_key", self.current_cities_key)
 
         self.settings.setValue("trends_earth/region_of_interest/custom_crs_enabled", self.groupBox_custom_crs.isChecked())
-        if self.groupBox_custom_crs.isChecked():
-            self.settings.setValue(
-                "trends_earth/region_of_interest/custom_crs",
-                self.mQgsProjectionSelectionWidget.crs().authid())
 
 
 class DlgSettingsRegister(QtWidgets.QDialog, Ui_DlgSettingsRegister):


### PR DESCRIPTION
Fixes #358

Using the mockup in https://github.com/ConservationInternational/trends.earth/issues/358 I have added a scroll area because the region content were making the setting dialogue height so large that It could fit screen.

Removed the region/point configuration in the algorithm now they are only available via Settings dialogue.
Screenshot
![latest_settings](https://user-images.githubusercontent.com/2663775/107780803-3c3b4900-6d58-11eb-802d-b9adbf27c202.gif)
