### PR TITLE
Datasets periodic refresh and centralised Jobs/Datasets memory store management. Fixes #375

### DIFF
--- a/LDMP/__init__.py
+++ b/LDMP/__init__.py
@@ -18,6 +18,7 @@ import re
 import site
 import json
 import subprocess
+import datetime
 from tempfile import NamedTemporaryFile
 
 from qgis.PyQt.QtCore import (QSettings, QTranslator, qVersion, 
@@ -133,3 +134,20 @@ def openFolder(path):
         subprocess.check_call(['xdg-open', path])
     elif sys.platform == 'win32':
         subprocess.check_call(['explorer', path])
+
+# singleton decorator
+def singleton(cls):
+    instances = {}
+    def wrapper(*args, **kwargs):
+        if cls not in instances:
+          instances[cls] = cls(*args, **kwargs)
+        return instances[cls]
+    return wrapper
+
+
+def json_serial(obj):
+    """JSON serializer for objects not serializable by default json code"""
+    if isinstance(obj, (datetime.datetime, datetime.date)):
+        return obj.isoformat()
+    raise TypeError("Type {} not serializable".format(type(obj)))
+

--- a/LDMP/api.py
+++ b/LDMP/api.py
@@ -17,12 +17,14 @@ standard_library.install_aliases()
 from builtins import object
 import sys
 import time
+import json
 from datetime import datetime
 from dateutil import tz
 import requests
 import json
 from urllib.parse import quote_plus
 
+import marshmallow
 from qgis.PyQt.QtCore import QCoreApplication, QSettings, QEventLoop
 from qgis.PyQt.QtWidgets import QMessageBox
 
@@ -404,12 +406,54 @@ def register(email, name, organization, country):
     return call_api('/api/v1/user', method='post', payload=payload)
 
 
-def run_script(script, params={}):
+def run_script(script_metadata, params={}):
     # TODO: check before submission whether this payload and script ID has
     # been sent recently - or even whether there are results already
     # available for it. Notify the user if this is the case to prevent, or
     # at least reduce, repeated identical submissions.
-    return call_api(u'/api/v1/script/{}/run'.format(quote_plus(script)), 'post', params, use_token=True)
+    script_name = script_metadata[0]
+    script_slug = script_metadata[1]
+
+    # run a script needs the following steps
+    # 1st step) run it
+    resp = call_api(u'/api/v1/script/{}/run'.format(quote_plus(script_slug)), 'post', params, use_token=True)
+
+    # 2nd step) save returned processing data as json file as process placeholder
+    if resp:
+        # data = resp['data']
+        # only a job should be available as response
+        # if len(data) != 1:
+        #     QMessageBox.critical(None, "Error", tr_api.tr(u"More than one jobs returned running script. Only newest will be get as run representative"))
+        # data = sorted(data, key=lambda job_dict: round(datetime.strptime(job_dict['start_date'], '%Y-%m-%dT%H:%M:%S.%f').timestamp()), reverse=True)
+        job_dict = resp['data']
+
+        # Convert start/end dates into datatime objects in local time zone
+        # the reason is to allog parsin using JobSchema based on APIResponseSchema
+        start_date = datetime.strptime(job_dict['start_date'], '%Y-%m-%dT%H:%M:%S.%f')
+        start_date = start_date.replace(tzinfo=tz.tzutc())
+        start_date = start_date.astimezone(tz.tzlocal())
+        # job_dict['start_date'] = datetime.strftime(start_date, '%Y/%m/%d (%H:%M)')
+        job_dict['start_date'] = start_date
+        end_date = job_dict.get('end_date', None)
+        if end_date:
+            end_date = datetime.strptime(end_date, '%Y-%m-%dT%H:%M:%S.%f')
+            end_date = end_date.replace(tzinfo=tz.tzutc())
+            end_date = end_date.astimezone(tz.tzlocal())
+            # job_dict['end_date'] = datetime.strftime(end_date, '%Y/%m/%d (%H:%M)')
+            job_dict['end_date'] = end_date
+        job_dict['task_name'] = job_dict['params'].get('task_name', '')
+        job_dict['task_notes'] = job_dict['params'].get('task_notes', '')
+        job_dict['params'] = job_dict['params']
+        job_dict['script'] = {"name": script_name, "slug": script_slug}
+
+        # do import here to avoid circular import
+        from LDMP.jobs import Jobs
+        from LDMP.models.datasets import Datasets
+        jobFileName, job = Jobs().append(job_dict)
+        Datasets().appendFromJob(job)
+        Datasets().updated.emit()
+
+    return resp
 
 
 def update_user(email, name, organization, country):
@@ -441,19 +485,23 @@ def get_execution(id=None, date=None):
     if not resp:
         return None
     else:
+        # do import here to avoid circular import
+        from LDMP.jobs import Job, JobSchema
+
         data = resp['data']
         # Sort responses in descending order using start time by default
-        data = sorted(data, key=lambda job: job['start_date'], reverse=True)
+        data = sorted(data, key=lambda job_dict: round(datetime.strptime(job_dict['start_date'], '%Y-%m-%dT%H:%M:%S.%f').timestamp()), reverse=True)
         # Convert start/end dates into datatime objects in local time zone
-        for job in data:
-            start_date = datetime.strptime(job['start_date'], '%Y-%m-%dT%H:%M:%S.%f')
+        for job_dict in data:
+            start_date = datetime.strptime(job_dict['start_date'], '%Y-%m-%dT%H:%M:%S.%f')
             start_date = start_date.replace(tzinfo=tz.tzutc())
             start_date = start_date.astimezone(tz.tzlocal())
-            job['start_date'] = start_date
-            end_date = datetime.strptime(job['end_date'], '%Y-%m-%dT%H:%M:%S.%f')
+            job_dict['start_date'] = start_date
+            end_date = datetime.strptime(job_dict['end_date'], '%Y-%m-%dT%H:%M:%S.%f')
             end_date = end_date.replace(tzinfo=tz.tzutc())
             end_date = end_date.astimezone(tz.tzlocal())
-            job['end_date'] = end_date
+            job_dict['end_date'] = end_date
+
         return data
 
 

--- a/LDMP/calculate.py
+++ b/LDMP/calculate.py
@@ -74,7 +74,15 @@ with open(os.path.join(os.path.dirname(os.path.realpath(__file__)),
 def get_script_slug(script_name):
     # Note that dots and underscores can't be used in the slugs, so they are 
     # replaced with dashesk
-    return script_name + '-' + scripts[script_name]['script version'].replace('.', '-')
+    return (script_name, script_name + '-' + scripts[script_name]['script version'].replace('.', '-'))
+
+def get_script_group(script_name):
+    # get the configured name of the group that belongs the script
+    group = None
+    if (script_name in scripts) and ('group' in scripts[script_name]):
+        group = scripts[script_name]['group']
+    return group
+
 
 # Transform CRS of a layer while optionally wrapping geometries
 # across the 180th meridian

--- a/LDMP/data/scripts.json
+++ b/LDMP/data/scripts.json
@@ -1,15 +1,18 @@
 {
     "time-series": {
         "script version": "1.0.3",
-        "description": "Calculate time series."
+        "description": "Calculate time series.",
+        "group": ""
     },
     "land-cover": {
         "script version": "1.0.3",
-        "description": "Calculate land cover change indicator."
+        "description": "Calculate land cover change indicator.",
+        "group": "SDG 15.3.1"
     },
     "productivity": {
         "script version": "1.0.3",
         "description": "Calculate productivity state, performance, and/or trajectory indicators.",
+        "group": "SDG 15.3.1",
         "trajectory functions": {
             "NDVI trends": {
                 "params": {"trajectory_method": "ndvi_trend"},
@@ -35,26 +38,32 @@
     },
     "soil-organic-carbon": {
         "script version": "1.0.3",
-        "description": "Calculate soil organic carbon."
+        "description": "Calculate soil organic carbon.",
+        "group": "SDG 15.3.1"
     },
     "sdg-sub-indicators": {
         "script version": "1.0.3",
-        "description": "Calculate all three SDG sub-indicators in one step."
+        "description": "Calculate all three SDG sub-indicators in one step.",
+        "group": "SDG 15.3.1"
     },
     "download-data": {
         "script version": "1.0.3",
-        "description": "Download data from Google Earth Engine assets."
+        "description": "Download data from Google Earth Engine assets.",
+        "group": ""
     },
     "total-carbon": {
         "script version": "1.0.3",
-        "description": "Calculate total carbon in biomass (above and below ground)."
+        "description": "Calculate total carbon in biomass (above and below ground).",
+        "group": ""
     },
     "urban-area": {
         "script version": "1.0.3",
-        "description": "Calculate urban area."
+        "description": "Calculate urban area.",
+        "group": ""
     },
     "restoration-biomass": {
         "script version": "1.0.3",
-        "description": "Calculate potential change in biomass with restoration."
+        "description": "Calculate potential change in biomass with restoration.",
+        "group": ""
     }
 }

--- a/LDMP/gui/WidgetDatasetItem.ui
+++ b/LDMP/gui/WidgetDatasetItem.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>345</width>
-    <height>152</height>
+    <height>181</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -86,12 +86,9 @@
          </widget>
         </item>
         <item>
-         <widget class="QGraphicsView" name="graphicsViewStatus">
-          <property name="maximumSize">
-           <size>
-            <width>20</width>
-            <height>20</height>
-           </size>
+         <widget class="QPushButton" name="pushButtonStatus">
+          <property name="text">
+           <string/>
           </property>
          </widget>
         </item>

--- a/LDMP/jobs.py
+++ b/LDMP/jobs.py
@@ -14,17 +14,20 @@
 
 from builtins import zip
 from builtins import range
+from typing import Optional, List, Dict
 import os
 import json
 import re
 import copy
 import base64
 import binascii
-
+import copy
 import datetime
+from dateutil import tz
+import pprint
 from qgis.PyQt import QtWidgets
 from qgis.PyQt.QtCore import (QSettings, QAbstractTableModel, Qt, pyqtSignal, 
-        QSortFilterProxyModel, QSize, QObject, QEvent, QCoreApplication)
+        QSortFilterProxyModel, QSize, QObject, QEvent, QCoreApplication, QObject)
 from qgis.PyQt.QtGui import QFontMetrics
 
 from osgeo import gdal
@@ -33,28 +36,24 @@ from qgis.utils import iface
 mb = iface.messageBar()
 
 from qgis.gui import QgsMessageBar
+from qgis.core import QgsLogger
 
 from LDMP.gui.DlgJobs import Ui_DlgJobs
 from LDMP.gui.DlgJobsDetails import Ui_DlgJobsDetails
 from LDMP.plot import DlgPlotTimeries
 
-from LDMP import log
+from LDMP import log, singleton, json_serial
 from LDMP.api import get_user_email, get_execution
 from LDMP.download import Download, check_hash_against_etag, DownloadError
 from LDMP.layers import add_layer
-from LDMP.schemas.schemas import LocalRaster, LocalRasterSchema
+from LDMP.schemas.schemas import LocalRaster, LocalRasterSchema, APIResponseSchema
+from LDMP.calculate import get_script_group
 
+import marshmallow
 
 class tr_jobs(object):
     def tr(message):
         return QCoreApplication.translate("tr_jobs", message)
-
-
-def json_serial(obj):
-    """JSON serializer for objects not serializable by default json code"""
-    if isinstance(obj, (datetime.datetime, datetime.date)):
-        return obj.isoformat()
-    raise TypeError("Type {} not serializable".format(type(obj)))
 
 
 def create_gee_json_metadata(json_file, job, data_file):
@@ -63,6 +62,8 @@ def create_gee_json_metadata(json_file, job, data_file):
     metadata = copy.deepcopy(job)
     bands = metadata['results'].pop('bands')
     metadata.pop('raw')
+
+    # TODO: how to link dumped LocalRaster data with Job class in self.jobsStore
 
     out = LocalRaster(os.path.basename(os.path.normpath(data_file)), bands, metadata)
     local_raster_schema = LocalRasterSchema()
@@ -104,6 +105,8 @@ class DlgJobs(QtWidgets.QDialog, Ui_DlgJobs):
         self.download.setEnabled(False)
 
         self.jobs_view.viewport().installEventFilter(tool_tipper(self.jobs_view))
+
+        self.jobs = Jobs()
 
     def showEvent(self, event):
         super(DlgJobs, self).showEvent(event)
@@ -154,15 +157,8 @@ class DlgJobs(QtWidgets.QDialog, Ui_DlgJobs):
         #######################################################################
         #######################################################################
 
-        try:
-            jobs_cache = json.loads(QSettings().value("LDMP/jobs_cache", '{}'))
-        except TypeError:
-            # For backward compatibility need to handle case of jobs caches 
-            # that were stored inappropriately in past version of Trends.Earth
-            jobs_cache = {}
-        if jobs_cache is not {}:
-            self.jobs = jobs_cache
-            self.update_jobs_table()
+        self.jobs.sync()
+        self.update_jobs_table()
 
     def connection_event_changed(self, flag):
         if flag:
@@ -183,7 +179,7 @@ class DlgJobs(QtWidgets.QDialog, Ui_DlgJobs):
         else:
             rows = set(list(index.row() for index in self.jobs_view.selectedIndexes()))
             job_ids = [self.proxy_model.index(row, 4).data() for row in rows]
-            statuses = [job.get('status', None) for job in self.jobs if job.get('id', None) in job_ids]
+            statuses = [job.get('status', None) for job in self.jobs.list() if job.get('id', None) in job_ids]
 
             if len(statuses) > 0:
                 for status in statuses:
@@ -201,9 +197,10 @@ class DlgJobs(QtWidgets.QDialog, Ui_DlgJobs):
             start_date = datetime.datetime.now() + datetime.timedelta(-14)
             jobs = get_execution(date=start_date.strftime('%Y-%m-%d'))
             if jobs:
-                self.jobs = jobs
+                self.jobs.set(jobs)
+                jobs_list = self.jobs.list()
                 # Add script names and descriptions to jobs list
-                for job in self.jobs:
+                for job in jobs_list:
                     # self.jobs will have prettified data for usage in table,
                     # so save a backup of the original data under key 'raw'
                     job['raw'] = job.copy()
@@ -222,7 +219,7 @@ class DlgJobs(QtWidgets.QDialog, Ui_DlgJobs):
                         job['script_description'] = self.tr('Script not found')
 
                 # Pretty print dates and pull the metadata sent as input params
-                for job in self.jobs:
+                for job in jobs_list:
                     job['start_date'] = datetime.datetime.strftime(job['start_date'], '%Y/%m/%d (%H:%M)')
                     job['end_date'] = datetime.datetime.strftime(job['end_date'], '%Y/%m/%d (%H:%M)')
                     job['task_name'] = job['params'].get('task_name', '')
@@ -230,7 +227,7 @@ class DlgJobs(QtWidgets.QDialog, Ui_DlgJobs):
                     job['params'] = job['params']
 
                 # Cache jobs for later reuse
-                QSettings().setValue("LDMP/jobs_cache", json.dumps(self.jobs, default=json_serial))
+                QSettings().setValue("LDMP/jobs_cache", json.dumps(jobs_list, default=json_serial))
 
                 self.update_jobs_table()
                 self.connectionEvent.emit(False)
@@ -239,14 +236,22 @@ class DlgJobs(QtWidgets.QDialog, Ui_DlgJobs):
         self.connectionEvent.emit(False)
         return False
 
+    def sync(self):
+        """Method to sync jobs in "trends_earth/advanced/base_data_directory" with that currently available.
+
+        The method parse content o base_data_directory and ????remove????? all Jobs not presents
+        in currently downloaded jobs
+        """
+        # TODO: NOT YET IMPLEMENTED
+
     def update_jobs_table(self):
         if self.jobs:
-            table_model = JobsTableModel(self.jobs, self)
+            table_model = JobsTableModel(self.jobs.list(), self)
             self.proxy_model = QSortFilterProxyModel()
             self.proxy_model.setSourceModel(table_model)
             self.jobs_view.setModel(self.proxy_model)
             # Add "Details" buttons in cell
-            for row in range(0, len(self.jobs)):
+            for row in range(0, len(self.jobs.list())):
                 btn = QtWidgets.QPushButton(self.tr("Details"))
                 btn.clicked.connect(self.btn_details)
                 self.jobs_view.setIndexWidget(self.proxy_model.index(row, 6), btn)
@@ -261,14 +266,13 @@ class DlgJobs(QtWidgets.QDialog, Ui_DlgJobs):
 
             self.jobs_view.selectionModel().selectionChanged.connect(self.selection_changed)
 
-
     def btn_details(self):
         button = self.sender()
         index = self.jobs_view.indexAt(button.pos())
 
         details_dlg = DlgJobsDetails(self)
 
-        job = self.jobs[index.row()]
+        job = self.jobs.list()[index.row()]
 
         details_dlg.task_name.setText(job.get('task_name', ''))
         details_dlg.task_status.setText(job.get('status', ''))
@@ -281,9 +285,11 @@ class DlgJobs(QtWidgets.QDialog, Ui_DlgJobs):
 
     def btn_download(self):
         # Use set below in case multiple cells within the same row are selected
+        jobs_list = self.jobs.list()
+
         rows = set(list(index.row() for index in self.jobs_view.selectedIndexes()))
         job_ids = [self.proxy_model.index(row, 4).data() for row in rows]
-        jobs = [job for job in self.jobs if job['id'] in job_ids]
+        jobs = [job for job in jobs_list if job['id'] in job_ids]
 
         filenames = []
         for job in jobs:
@@ -324,7 +330,7 @@ class DlgJobs(QtWidgets.QDialog, Ui_DlgJobs):
         self.close()
 
         for row, f in zip(rows, filenames):
-            job = self.jobs[row]
+            job = jobs_list[row]
             log(u"Processing job {}.".format(job.get('id', None)))
             result_type = job['results'].get('type')
             if result_type == 'CloudResults':
@@ -336,7 +342,7 @@ class DlgJobs(QtWidgets.QDialog, Ui_DlgJobs):
 
 
 class JobsTableModel(QAbstractTableModel):
-    def __init__(self, datain, parent=None, *args):
+    def __init__(self, datain: List[dict], parent=None, *args):
         QAbstractTableModel.__init__(self, parent, *args)
         self.jobs = datain
 
@@ -472,3 +478,182 @@ def download_timeseries(job, tr):
     dlg_plot.plot_data(data['time'], data['y'], labels)
     dlg_plot.show()
     dlg_plot.exec_()
+
+
+################################################################################
+# Job class and Schema for Job descriptor build from APIResponseSchema
+class Job(QObject):
+
+    # TODO: create a uniform way to manage Jobs. or self.jobs is a list of dict 
+    # or a list of Job instances. Temporarly maintaining the two structure to reduce
+    # side effects
+
+    # emit signal when a Job is dumped (useful in case have to update Datasets)
+    dumped = pyqtSignal(str) 
+
+    def __init__(self, response: APIResponseSchema):
+        super().__init__()
+
+        QgsLogger.debug('* Build Job from response: ' + pprint.pformat(response), debuglevel=5)
+
+        self.raw = response
+
+        self.response = {}
+        self.response['id'] = response.get('id', 'Unknown')
+        self.response['start_date'] = response.get('start_date', datetime.datetime(1,1,1,0,0))
+        self.response['end_date'] = response.get('end_date', datetime.datetime(1,1,1,0,0))
+        self.response['status'] = response.get('status', '')
+        self.response['progress'] = response.get('progress', 0)
+        self.response['params'] = response.get('params', {})
+        self.response['results'] = response.get('results', None)
+        self.response['script'] = response.get('script', {})
+        self.response['logs'] = response.get('logs', '')
+
+    @property
+    def status(self) -> str:
+        # return processing status
+        return self.response['status']
+
+    @property
+    def progress(self) -> int:
+        # return processing progress
+        return self.response['progress']
+
+    @property
+    def taskName(self) -> Optional[str]:
+        return self.response['params'].get('task_name', '')
+
+    @property
+    def scriptName(self) -> Optional[str]:
+        return self.response['script'].get('name', '')
+
+    @property
+    def runId(self) -> str:
+        return self.response['id']
+
+    @property
+    def startDate(self) -> datetime.datetime:
+        return self.response['start_date']
+
+    def dump(self) -> str:
+        """Dump Job as JSON in a programmatically set folder with a programmaticaly set filename.
+        """
+        # create path and filname where to dump Job descriptor
+        out_path = ''
+        base_data_directory = QSettings().value("trends_earth/advanced/base_data_directory", None, type=str)
+        out_path = os.path.join(base_data_directory, 'jobs')
+
+        # set location where to save basing on script(alg) used
+        script_name = self.response['script']['name']
+        components = script_name.split()
+        components = components[:-1] if len(components) > 1 else components # eventually remove version that return when get exeutions list
+        formatted_script_name = '-'.join(components) # remove al version and substitutes ' ' with '-'
+        formatted_script_name = formatted_script_name.lower()
+
+        # get alg group to setup subfolder
+        group = get_script_group(formatted_script_name)
+        if not group:
+            log(tr_jobs.tr('Cannot get group of the script: ') + formatted_script_name)
+            group = 'UNKNOW_GROUP_FOR_' + formatted_script_name
+
+        # get exectuion date as subfolder name
+        processing_date_string = self.response['start_date'].strftime('%Y_%m_%d')
+
+        out_path = os.path.join(out_path, group, processing_date_string)
+        if not os.path.exists(out_path):
+            os.makedirs(out_path)
+
+        job_descriptor_file_name = self.response['id'] + '.json'
+        job_descriptor_file_name = os.path.join(out_path, job_descriptor_file_name)
+        QgsLogger.debug('* Dump job descriptor into file: '+ job_descriptor_file_name, debuglevel=4)
+
+        job_schema = JobSchema()
+        with open(job_descriptor_file_name, 'w') as f:
+            json_to_write = json.dump(
+                job_schema.dump(self),
+                f, default=json_serial, sort_keys=True, indent=4, separators=(',', ': ')
+            )
+        self.dumped.emit(job_descriptor_file_name)
+        return job_descriptor_file_name
+
+
+@singleton
+class Jobs(QObject):
+    """Singleton container to separate Dialog to Job operations as retrieve and update."""
+
+    updated = pyqtSignal()
+    jobsStore = {}
+
+    def __init__(self):
+        super().__init__()
+
+    def set(self, jobs_dict: Optional[List[dict]] = None):
+        # remove previous jobs
+        self.reset()
+
+        if jobs_dict is None:
+            return
+
+        # set new ones
+        for job_dict in jobs_dict:
+            self.append(job_dict)
+        self.updated.emit()
+
+    def sync(self) -> None:
+        """Sync Jobs from cache."""
+        try:
+            jobs_cache = json.loads(QSettings().value("LDMP/jobs_cache", '{}'))
+        except TypeError:
+            # For backward compatibility need to handle case of jobs caches 
+            # that were stored inappropriately in past version of Trends.Earth
+            jobs_cache = {}
+        if jobs_cache is not {}:
+            self.set(jobs_cache)
+            # self.update_jobs_table()
+
+    def append(self, job_dict: dict) -> (str, Job):
+        """Append a job dictionay and Job json contrepart in base_data_directory."""
+        # save Job descriptor in data directory
+        # in this way there is also a mimimum sanity check
+        # NOTE! need to adapt start and stop date to datetime object and not string to be used in 
+        # JobSchema based on APIResponseSchema
+        cloned_job = dict(job_dict)
+
+        if isinstance(cloned_job['start_date'], str):
+            cloned_job['start_date'] = datetime.datetime.strptime(cloned_job['start_date'], '%Y/%m/%d (%H:%M)')
+        cloned_job['start_date'] = cloned_job['start_date'].replace(tzinfo=tz.tzutc())
+        if isinstance(cloned_job['end_date'], str):
+            cloned_job['end_date'] = datetime.datetime.strptime(cloned_job['end_date'], '%Y/%m/%d (%H:%M)')
+        cloned_job['end_date'] = cloned_job['end_date'].replace(tzinfo=tz.tzutc())
+        cloned_job['end_date'] = cloned_job['end_date'].astimezone(tz.tzlocal())
+
+        schema = JobSchema()
+        response = schema.load(cloned_job, partial=True, unknown=marshmallow.INCLUDE)
+        job = Job(response)
+        dump_file_name = job.dump() # doing save in default location
+
+        # add in memory store .e.g a dictionary
+        self.jobsStore[dump_file_name] = job
+
+        return (dump_file_name, job)
+
+    def list(self):
+        """Return response dictionary generated the Job.
+
+        This method is to manitain good compatibility with older code e.g. with minimal refactoring
+        """
+        return [ job.raw for job in self.jobsStore.values() ]
+
+    def classes(self):
+        return [ job for job in self.jobsStore.values() ]
+
+    def reset(self):
+        """Remove any jobs and related json contrepart."""
+        # remove any json of the available Jobs in self.jobs
+        for file_name in self.jobsStore.keys():
+            os.remove(file_name)
+        self.jobsStore = {}
+        self.updated.emit()
+
+class JobSchema(marshmallow.Schema):
+    response = marshmallow.fields.Nested(APIResponseSchema, many=False)

--- a/LDMP/main_widget.py
+++ b/LDMP/main_widget.py
@@ -80,7 +80,8 @@ class MainWidget(QtWidgets.QDockWidget, Ui_dockWidget_trends_earth):
         # setup Jobs singleton store and all update mechanisms
         # self.jobs = Jobs()
 
-        # setup Datasets singleton store and Model update mechanism
+        # setup Datasets and Jobs singleton store and Model update mechanism
+        Jobs().updated.connect(self.updateDatasetsModel)
         Datasets().updated.connect(self.updateDatasetsModel)
 
         self.setupAlgorithmsTree()

--- a/LDMP/main_widget.py
+++ b/LDMP/main_widget.py
@@ -14,7 +14,7 @@
 
 from datetime import datetime
 
-from qgis.PyQt import QtWidgets, QtGui
+from qgis.PyQt import QtWidgets, QtGui, QtCore
 from qgis.core import QgsSettings
 
 from LDMP import __version__, log
@@ -26,6 +26,8 @@ from LDMP.models.algorithms import (
     AlgorithmRunMode,
     AlgorithmDetails
 )
+
+from LDMP.jobs import Jobs
 from LDMP.models.datasets import (
     Dataset,
     Datasets
@@ -50,16 +52,17 @@ settings = QgsSettings()
 _widget = None
 
 
-def get_trends_earth_dockwidget():
+def get_trends_earth_dockwidget(plugin):
     global _widget
     if _widget is None:
-        _widget = MainWidget()
+        _widget = MainWidget(plugin=plugin)
     return _widget
 
 
 class MainWidget(QtWidgets.QDockWidget, Ui_dockWidget_trends_earth):
-    def __init__(self, parent=None):
+    def __init__(self, plugin=None, parent=None):
         super(MainWidget, self).__init__(parent)
+        self.plugin = plugin
 
         self.setupUi(self)
 
@@ -74,10 +77,38 @@ class MainWidget(QtWidgets.QDockWidget, Ui_dockWidget_trends_earth):
         self.dlg_calculate_Biomass = DlgCalculateRestBiomass()
         self.dlg_calculate_Urban = DlgCalculateUrban()
 
-        self.setupAlgorithmsTree()
-        self.setupDatasets()
+        # setup Jobs singleton store and all update mechanisms
+        # self.jobs = Jobs()
 
-    def setupDatasets(self):
+        # setup Datasets singleton store and Model update mechanism
+        Datasets().updated.connect(self.updateDatasetsModel)
+
+        self.setupAlgorithmsTree()
+        self.setupDatasetsGui()
+        self.updateDatasetsBasedOnJobs()
+
+    def updateDatasetsBasedOnJobs(self):
+        """Sync Datasets basing on available Jobs.
+
+        The conditions are:
+        - If Job.progress < 100 => generate and dumps related Datasets
+        - If Job.progress == 100 && if related datasets is not downloaded => generate and dumps related Datasets
+        """
+        # update Jobs getting them from cached
+        Jobs().sync()
+        for job in Jobs().classes():
+            if job.progress == 100:
+                # TODO: check if dataset is in downloading or downloaded e.g. available = true
+                available = False
+                if available:
+                    continue
+            
+            Datasets().appendFromJob(job)
+
+        # add any other datasets available
+        Datasets().sync()
+
+    def setupDatasetsGui(self):
         # add sort actions
         self.toolButton_sort.setMenu(QtWidgets.QMenu())
 
@@ -96,43 +127,78 @@ class MainWidget(QtWidgets.QDockWidget, Ui_dockWidget_trends_earth):
         icon = QtGui.QIcon(':/plugins/LDMP/icons/mActionSharingImport.svg')
         self.pushButton_download.setIcon(icon)
 
-        # example of datasets
-        date_ = datetime.strptime('2021-01-20 10:30:00', '%Y-%m-%d %H:%M:%S')
-        datasets = Datasets(
-            [
-                Dataset('1dataset1', date_, 'Land productivity', run_id='run_id_1'),
-                Dataset('2dataset2', date_, 'Downloaded from sample dataset', run_id='run_id_2'),
-                Dataset('3dataset3', date_, 'Land change', run_id='run_id_3'),
-                Dataset('11Productivity Trajectory1', date_, 'Land Productivity (SDG 15.3.1 sub-indicator1)', run_id='run_id_4'),
-                Dataset('22Productivity Trajectory2', date_, 'Land Productivity (SDG 15.3.1 sub-indicator1)', run_id='run_id_5'),
-                Dataset('33Productivity Trajectory3', date_, 'Land Productivity (SDG 15.3.1 sub-indicator1)', run_id='run_id_6'),
-                Dataset('44Productivity Trajectory4', date_, 'Land Productivity (SDG 15.3.1 sub-indicator1)', run_id='run_id_7'),
-                Dataset('55Productivity Trajectory5', date_, 'Land Productivity (SDG 15.3.1 sub-indicator1)', run_id='run_id_8'),
-                Dataset('66Productivity Trajectory6', date_, 'Land Productivity (SDG 15.3.1 sub-indicator1)', run_id='run_id_9'),
-                Dataset(
-                    '111 A very very very  much much big name with a lot of many many many many words',
-                    date_,
-                    'Land Productivity (SDG 15.3.1 sub-indicator1)', run_id='run_id_10'
-                ),
-                Dataset(
-                    '222 A very very very  much much big name with a lot of many many many many words',
-                    date_,
-                    'A very very very  much much big name with a lot of many many many many words', run_id='run_id_11'
-                ),
-            ]
-        )
+        # set manual and automatic refresh of datasets
+        # avoid using lambda or partial to allow not anonymous callback => can be remove if necessary
+        def refreshWithotAutorefresh():
+            self.refreshDatasets(autorefresh=False)
+        self.pushButton_refresh.clicked.connect(refreshWithotAutorefresh) 
 
-        # show it
-        datasetsModel = DatasetsModel(datasets)
+        # set automatic refresh
+        refresh_polling_time = QtCore.QSettings().value("trends_earth/advanced/refresh_polling_time", 60000, type=int)
+        if refresh_polling_time > 0:
+            QtCore.QTimer.singleShot(refresh_polling_time, self.refreshDatasets)
+
+
+        # configure view
         self.treeView_datasets.setMouseTracking(True) # to allow emit entered events and manage editing over mouse
         self.treeView_datasets.setWordWrap(True) # add ... to wrap DisplayRole text... to have a real wrap need a custom widget
-        self.treeView_datasets.setModel(datasetsModel)
-        delegate = DatasetItemDelegate(self.treeView_datasets)
+        delegate = DatasetItemDelegate(self.plugin, self.treeView_datasets)
         self.treeView_datasets.setItemDelegate(delegate)
-
         # configure View how to enter editing mode
         self.treeView_datasets.setEditTriggers(QtWidgets.QAbstractItemView.AllEditTriggers)
 
+        # example of datasets
+        # date_ = datetime.strptime('2021-01-20 10:30:00', '%Y-%m-%d %H:%M:%S')
+        # datasets = Datasets()
+
+        # sync datasets available in base_data_directory
+        # datasets.sync()
+        #     [
+        #         Dataset('1dataset1', date_, 'Land productivity', run_id='run_id_1'),
+        #         Dataset('2dataset2', date_, 'Downloaded from sample dataset', run_id='run_id_2'),
+        #         Dataset('3dataset3', date_, 'Land change', run_id='run_id_3'),
+        #         Dataset('11Productivity Trajectory1', date_, 'Land Productivity (SDG 15.3.1 sub-indicator1)', run_id='run_id_4'),
+        #         Dataset('22Productivity Trajectory2', date_, 'Land Productivity (SDG 15.3.1 sub-indicator1)', run_id='run_id_5'),
+        #         Dataset('33Productivity Trajectory3', date_, 'Land Productivity (SDG 15.3.1 sub-indicator1)', run_id='run_id_6'),
+        #         Dataset('44Productivity Trajectory4', date_, 'Land Productivity (SDG 15.3.1 sub-indicator1)', run_id='run_id_7'),
+        #         Dataset('55Productivity Trajectory5', date_, 'Land Productivity (SDG 15.3.1 sub-indicator1)', run_id='run_id_8'),
+        #         Dataset('66Productivity Trajectory6', date_, 'Land Productivity (SDG 15.3.1 sub-indicator1)', run_id='run_id_9'),
+        #         Dataset(
+        #             '111 A very very very  much much big name with a lot of many many many many words',
+        #             date_,
+        #             'Land Productivity (SDG 15.3.1 sub-indicator1)', run_id='run_id_10'
+        #         ),
+        #         Dataset(
+        #             '222 A very very very  much much big name with a lot of many many many many words',
+        #             date_,
+        #             'A very very very  much much big name with a lot of many many many many words', run_id='run_id_11'
+        #         ),
+        #     ]
+        # )
+
+        # show it
+
+    def refreshDatasets(self, autorefresh=True):
+        """Refresh datasets is composed of the following steps:
+        1) Get all executions (e.g. Jobs)
+        2) Rebuild and dump Datasets based on the downloaded Jobs
+
+        Due to API limitation it's not possible to query a job one by one but only get all jobs in a time window.
+        """
+        # use method of toher plgun GUIs to fetch all executions
+        if not self.plugin:
+            return
+        self.plugin.dlg_jobs.btn_refresh()
+        self.updateDatasetsBasedOnJobs()
+
+        # depending on config re-trigger it
+        refresh_polling_time = QtCore.QSettings().value("trends_earth/advanced/refresh_polling_time", 60000, type=int)
+        if autorefresh and refresh_polling_time > 0:
+            QtCore.QTimer.singleShot(refresh_polling_time, self.refreshDatasets)
+
+    def updateDatasetsModel(self):
+        datasetsModel = DatasetsModel( Datasets() )  # Datasets is a singleton
+        self.treeView_datasets.setModel(datasetsModel)
 
     def setupAlgorithmsTree(self):
         # setup algorithms and their hierarchy

--- a/LDMP/main_widget.py
+++ b/LDMP/main_widget.py
@@ -199,6 +199,7 @@ class MainWidget(QtWidgets.QDockWidget, Ui_dockWidget_trends_earth):
 
     def updateDatasetsModel(self):
         datasetsModel = DatasetsModel( Datasets() )  # Datasets is a singleton
+        self.treeView_datasets.reset()
         self.treeView_datasets.setModel(datasetsModel)
 
     def setupAlgorithmsTree(self):

--- a/LDMP/message_bar.py
+++ b/LDMP/message_bar.py
@@ -14,15 +14,7 @@
 
 from qgis.gui import QgsMessageBar
 from qgis.utils import iface
-
-# singleton decorator
-def singleton(cls):
-    instances = {}
-    def wrapper(*args, **kwargs):
-        if cls not in instances:
-          instances[cls] = cls(*args, **kwargs)
-        return instances[cls]
-    return wrapper
+from LDMP import singleton
 
 @singleton
 class MessageBar(object):

--- a/LDMP/models/datasets.py
+++ b/LDMP/models/datasets.py
@@ -14,39 +14,63 @@
 __author__ = 'Luigi Pirelli / Kartoza'
 __date__ = '2021-03-23'
 
-from typing import Optional, Union, List
+from typing import Optional, Union, List, Dict
 from datetime import datetime
 from enum import Enum
 import abc
+import os
+import json
+from collections import OrderedDict
+
+from qgis.PyQt.QtCore import QSettings, pyqtSignal, QObject
+from qgis.core import QgsLogger
+from LDMP.jobs import Job, JobSchema
+from LDMP.calculate import get_script_group
+from LDMP import log, singleton, tr, json_serial
+
+import marshmallow
+from marshmallow import fields, Schema
+from LDMP.schemas.schemas import APIResponseSchema
+
 
 class DatasetStatus(Enum):
+    """TODO: remove because simplified using the same Job status."""
     available = 0,
     being_generated = 1,
     downloading = 2,
     unavailable = 3,
     not_applicable = 4
+DatasetStatusStrings = [e.name for e in DatasetStatus]
 
 
-class DatasetSource(object):
-    def __init__(self):
+def getStatusEnum(status: str) -> DatasetStatus:
+    """TODO: remove as commented above"""
+    # get APIResponseSchema and remap into DatasetStatus
+    ds_status = DatasetStatus.not_applicable
+    if status in ['PENDING']:
+        ds_status = DatasetStatus.being_generated
+    elif status in ['SUCCESS', 'FINISHED']:
+        ds_status = DatasetStatus.available
+    else:
+        ds_status = DatasetStatus.not_applicable
+    
+    return ds_status
+
+
+# TODO: remove
+# class DatasetSource(object):
+#     def __init__(self):
+#         super().__init__()
+
+class FinalMeta(type(abc.ABC), type(QObject)):
+    """trick to allow multiple hineritance. Need to allow also QObject
+    hineritance to allow emitting pyqtSingla."""
+    pass
+class DatasetBase(abc.ABC, QObject, metaclass=FinalMeta):
+    """implemented a base class in case need to expand the three with new nodes."""
+
+    def __init__(self) -> None:
         super().__init__()
-
-
-# implemented a base class in case need to expand the three with new nodes
-class DatasetBase(abc.ABC):
-
-    def __init__(self,
-            name: str,
-            creation_date: datetime,
-            source: str,
-            run_id: str
-        ) -> None:
-        super().__init__()
-        self.status: DatasetStatus = DatasetStatus.not_applicable
-        self.source = source
-        self.run_id = run_id
-        self.name = name
-        self.creation_date = creation_date
 
     def row(self) -> int:
         return 0
@@ -66,17 +90,37 @@ class DatasetBase(abc.ABC):
 
 class Dataset(DatasetBase):
 
+    dumped = pyqtSignal(str)
+
     def __init__(self,
-            name: str,
-            creation_date: datetime,
-            source: str,
-            run_id: str
+            job: Optional[Job] = None,
+            dataset: Optional[Dict] = None
         ) -> None:
-        super().__init__(name, creation_date, source, run_id)
-        self.status: DatasetStatus = DatasetStatus.not_applicable
-        self.source = source
-        self.name = name
-        self.creation_date = creation_date
+        super().__init__()
+
+        if job:
+            job_schema = JobSchema()
+            self.job = job_schema.dump(job)
+
+            self.status: str = job.status
+            # self.status: DatasetStatus = getStatusEnum(job.status)
+            self.progress = job.progress
+            self.source = job.scriptName
+            self.name = job.taskName
+            self.creation_date = job.startDate
+            self.run_id = job.runId
+        elif dataset:
+            self.job = ''
+
+            self.status = dataset.get('status')
+            # self.status: DatasetStatus = getStatusEnum(job.status)
+            self.progress = dataset.get('progress')
+            self.source = dataset.get('source')
+            self.name = dataset.get('name')
+            self.creation_date = dataset.get('creation_date')
+            self.run_id = dataset.get('run_id')
+        else:
+            raise Exception('Nor input Job or dataset dictionary are set to build a Dataset instance')
 
     def columnCount(self) -> int:
         return 1
@@ -90,26 +134,179 @@ class Dataset(DatasetBase):
     def columnName(self, column: int) -> Union[str, None]:
         return None
 
-# Datasets is a class placeholder to be root of the tree. It shouldn't be
-# necessary in case of using QListView, but using TreeView to allow
-# more flexibility
-class Datasets(object):
-    datasets: List[Dataset]
+    def dump(self) -> str:
+        """Dump Dataset as JSON in a programmatically set folder with a programmaticaly set filename.
+        """
+        # create path and filname where to dump Job descriptor
+        out_path = ''
+        base_data_directory = QSettings().value("trends_earth/advanced/base_data_directory", None, type=str)
 
-    def __init__(self, datasets: Optional[List[Dataset]] = None):
+        # TODO: set subfolder basing on the nature of Dataset
+        # for now only 'ouptuts'
+        out_path = os.path.join(base_data_directory, 'ouptuts')
+
+        # set location where to save basing on script(alg) used
+        script_name = self.source
+        components = script_name.split()
+        components = components[:-1] if len(components) > 1 else components # eventually remove version that return when get exeutions list
+        formatted_script_name = '-'.join(components) # remove al version and substitutes ' ' with '-'
+        formatted_script_name = formatted_script_name.lower()
+
+        # get alg group to setup subfolder
+        group = get_script_group(formatted_script_name)
+        if not group:
+            log(tr('Cannot get group of the script: ') + formatted_script_name)
+            group = 'UNKNOW_GROUP_FOR_' + formatted_script_name
+
+        # get exectuion date as subfolder name
+        processing_date_string = self.creation_date
+        if isinstance(processing_date_string, datetime):
+            processing_date_string = self.creation_date.strftime('%Y_%m_%d')
+
+        out_path = os.path.join(out_path, group, processing_date_string)
+        if not os.path.exists(out_path):
+            os.makedirs(out_path)
+
+        descriptor_file_name = self.run_id + '.json'
+        descriptor_file_name = os.path.join(out_path, descriptor_file_name)
+        QgsLogger.debug('* Dump dataset descriptor into file: '+ descriptor_file_name, debuglevel=4)
+
+        schema = DatasetSchema()
+        with open(descriptor_file_name, 'w') as f:
+            json.dump(
+                schema.dump(self),
+                f, default=json_serial, sort_keys=True, indent=4, separators=(',', ': ')
+            )
+        self.dumped.emit(descriptor_file_name)
+        return descriptor_file_name
+
+
+@singleton
+class Datasets(QObject):
+    """Singleton container to separate Dialog to Job operations as retrieve and update.
+    
+    It shouldn't be necessary in case of using QListView, but using TreeView to allow
+    more flexibility.
+    """
+    datasetsStore: Dict[str, Dataset] = OrderedDict()
+    updated = pyqtSignal()
+
+    def __init__(self):
         super().__init__()
-        self.datasets = list(datasets) if datasets is not None else []
 
+    def reset(self, emit: bool = False):
+        """Remove any Datast and related json contrepart."""
+        # remove any json of the available Jobs in self.jobs
+        # for file_name in self.datasetsStore.keys():
+        #     os.remove(file_name)
+        self.datasetsStore = OrderedDict()
+        if emit:
+            self.updated.emit()
+
+    def set(self, datasets_dict: Optional[List[dict]] = None):
+        # remove previous jobs
+        self.reset()
+
+        if datasets_dict is None:
+            return
+
+        # set new ones
+        for dataset_dict in datasets_dict:
+            self.append(dataset_dict)
+        self.updated.emit()
+
+    def appendFromJob(self, job: Job) -> (str, Dataset):
+        """Create a Dataset and dump basing an assumed valid Job."""
+        dataset = Dataset(job=job)
+        dump_file_name = dataset.dump() # doing save in default location
+
+        # add in memory store .e.g a dictionary
+        self.datasetsStore[dump_file_name] = dataset
+
+        return (dump_file_name, dataset)
+
+    # method useful to interface with MVC model
     def columnCount(self) -> int:
         return 1
 
     def rowCount(self) -> int:
-        return len(self.datasets)
+        return len(self.datasetsStore)
     
     def child(self, row: int) -> Optional['Dataset']:
-        if row < 0 or row >= len(self.datasets):
+        if row < 0 or row >= len(self.datasetsStore):
             return None
-        return self.datasets[row]
+        return list(self.datasetsStore.items())[row][1]
     
     def columnName(self, column: int) -> Optional[str]:
         return None
+
+    def sync(self):
+        """Method to sync with Datasets available in "trends_earth/advanced/base_data_directory".
+
+        The method parse content o base_data_directory and create Dataset instance for each 
+        found Dataset descriptor.
+        """
+        base_data_directory = QSettings().value("trends_earth/advanced/base_data_directory", None, type=str)
+
+        def traverse(path):
+            excluded_path = os.path.sep + 'Jobs' + os.path.sep
+
+            for basepath, directories, files in os.walk(path):
+                for f in files:
+                    # skip files in Jobs
+                    if excluded_path.lower() in basepath.lower():
+                        continue
+                    
+                    yield os.path.join(basepath, f)
+
+        # remove any previous memorised Datasets
+        # self.reset()
+        schema = DatasetSchema()
+        for json_file in traverse(base_data_directory):
+            # skip larger thatn 1MB files
+            statinfo = os.stat(json_file)
+            if statinfo.st_size > 1024*1024:
+                continue
+
+            # skip any not json file
+            with open(json_file, 'r') as fd:
+                try:
+                    parsed_json = json.load(fd)
+                except json.decoder.JSONDecodeError as ex:
+                    # no json => skip
+                    continue
+                except Exception as ex:
+                    log(tr('Error reading file {} with ex: ').format(json_file, str(ex)))
+                    continue
+            
+                try:
+                    dataset_dict = schema.load(parsed_json, partial=True, unknown=marshmallow.INCLUDE)
+                    dataset = Dataset(dataset=dataset_dict)
+                    self.datasetsStore[json_file] = dataset
+
+                except marshmallow.exceptions.ValidationError as ex:
+                    log(tr('not a valid Dataset {} with ex: ').format(f, str(ex)))
+                    continue
+                except Exception as ex:
+                    # Exception notification managed in append method
+                    log(tr('Cannot manage dataset for file {} ex: {}').format(json_file, str(ex)))
+                    continue
+        self.updated.emit()
+
+
+class DatasetSchema(Schema):
+    """Schema defining structure of a dumped Dataset.
+    """
+    # job = fields.Nested(APIResponseSchema, many=False, required=False)
+    job = fields.Str(required=False)
+
+    status = fields.Str(required=True)
+    # status = fields.Str(
+    #     validate=validate.OneOf(DatasetStatusStrings), 
+    #     required=True
+    # )
+    progress = fields.Integer(required=True)
+    source = fields.Str(required=True)
+    name = fields.Str()
+    creation_date = fields.DateTime(required=True)
+    run_id = fields.UUID(required=True)

--- a/LDMP/models/datasets_model.py
+++ b/LDMP/models/datasets_model.py
@@ -14,7 +14,7 @@
 __author__ = 'Luigi Pirelli / Kartoza'
 __date__ = '2021-03-03'
 
-from typing import Optional, Union
+from typing import Optional
 from qgis.PyQt.QtCore import (
     QAbstractItemModel,
     QModelIndex,
@@ -49,15 +49,15 @@ class DatasetsModel(QAbstractItemModel):
 
         return self.rootItem.columnCount()
 
-    def data(self, index: QModelIndex = QModelIndex(), role: Qt.ItemDataRole = Qt.DisplayRole ) -> Union[Dataset, None]:
+    def data(self, index: QModelIndex = QModelIndex(), role: Qt.ItemDataRole = Qt.DisplayRole ) -> Optional[Dataset]:
         if not index.isValid():
             return None
 
         item = index.internalPointer()
         if role == Qt.DisplayRole:
             if index.column() == 0:
-                return item.name
-            
+                return list(self.rootItem.items())[index.row()].name
+
         if role == Qt.ItemDataRole:
             return item
 

--- a/LDMP/plugin.py
+++ b/LDMP/plugin.py
@@ -252,7 +252,7 @@ class LDMPPlugin(object):
     def run_docked_interface(self, checked):
         if checked:
             # add docked main interface
-            self.dock_widget = get_trends_earth_dockwidget()
+            self.dock_widget = get_trends_earth_dockwidget(plugin=self)
             self.iface.addDockWidget(Qt.RightDockWidgetArea, self.dock_widget)
             self.dock_widget.show()
         else:


### PR DESCRIPTION
Datasets are scanned from:

cached jobs
eventually any other josn present in base_data_directly (jumping jobs folder)
actually polling is set to 60000ms get form config: "trends_earth/advanced/refresh_polling_time"

next step are:

check for local generated Jobs/Datasets
download remote datasets
NOTE. There are some architecturally critical aspects:
A) Originally there is no difference between Job/Dataset => I hope I coded to avoid misalignments
B) Jobs=Dataset and Job list are only a API image of that available remotely => Jobs and Dataset are naturally aligned
C) Job Dataset are download in a user defined location. e.g. there is no constraint where to save datasets or job descriptors => this can be a source of misalignment.

To approach has these critical aspects:

Jobs and Datasets are sets of Job and Dataset and are singletons (kind of memory store with an image of it's components as json file in base_data_directory
Any Jobs or Dataset know where save itself (using dump method)
=> still need a procedure and criteria to clean Jobs/Datasets