### PR TITLE
Automatic/configurable datasets download. Fixes #376 #409

### DIFF
--- a/LDMP/__init__.py
+++ b/LDMP/__init__.py
@@ -19,6 +19,7 @@ import site
 import json
 import subprocess
 import datetime
+import threading
 from tempfile import NamedTemporaryFile
 
 from qgis.PyQt.QtCore import (QSettings, QTranslator, qVersion, 
@@ -139,8 +140,17 @@ def openFolder(path):
 def singleton(cls):
     instances = {}
     def wrapper(*args, **kwargs):
+        # eventually lock getting the instance in case it is in modiry state
+        if hasattr(cls, 'lock'):
+            cls.lock.acquire()
+        
         if cls not in instances:
           instances[cls] = cls(*args, **kwargs)
+        
+        # eventually unlock
+        if hasattr(cls, 'lock'):
+            cls.lock.release()
+
         return instances[cls]
     return wrapper
 

--- a/LDMP/gui/WidgetDatasetItem.ui
+++ b/LDMP/gui/WidgetDatasetItem.ui
@@ -51,6 +51,12 @@
        <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>
          <widget class="QLabel" name="labelDatasetName">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>31</height>
+           </size>
+          </property>
           <property name="font">
            <font>
             <weight>75</weight>

--- a/LDMP/jobs.py
+++ b/LDMP/jobs.py
@@ -14,7 +14,7 @@
 
 from builtins import zip
 from builtins import range
-from typing import Optional, List, Dict
+from typing import Optional, List, Dict, Tuple
 import os
 import json
 import re
@@ -538,6 +538,10 @@ class Job(QObject):
     def startDate(self) -> datetime.datetime:
         return self.response['start_date']
 
+    @property
+    def results(self) -> Optional[dict]:
+        return self.response['results']
+
     @staticmethod
     def datetimeRepr(dt: datetime.datetime) -> str:
         return datetime.datetime.strftime(dt, '%Y/%m/%d (%H:%M)')
@@ -654,6 +658,11 @@ class Jobs(QObject):
         This method is to manitain good compatibility with older code e.g. with minimal refactoring
         """
         return [ job.raw for job in self.jobsStore.values() ]
+
+    def jobById(self, id: str) -> Optional[Tuple[str, Job]]:
+        """Return Job and related descriptor asociated file."""
+        jobs = [(k, j) for k,j in self.jobsStore.items() if j.runId == id]
+        return jobs[0] if len(jobs) else None
 
     def classes(self):
         return [ job for job in self.jobsStore.values() ]

--- a/LDMP/jobs.py
+++ b/LDMP/jobs.py
@@ -671,7 +671,10 @@ class Jobs(QObject):
         """Remove any jobs and related json contrepart."""
         # remove any json of the available Jobs in self.jobs
         for file_name in self.jobsStore.keys():
-            os.remove(file_name)
+            try:
+                os.remove(file_name)
+            except:
+                pass
         self.jobsStore = {}
         self.updated.emit()
 

--- a/LDMP/jobs.py
+++ b/LDMP/jobs.py
@@ -449,10 +449,19 @@ def download_cloud_results(job, f, tr, add_to_map=True):
     else:
         url = results['urls'][0]
         out_file = f + '.tif'
-        resp = download_result(url['url'], out_file, job, 
-                               binascii.hexlify(base64.b64decode(url['md5Hash'])).decode())
-        if not resp:
-            return
+        do_download = True
+        if os.access(out_file, os.R_OK):
+            if check_hash_against_etag(url['url'], out_file, binascii.hexlify(base64.b64decode(url['md5Hash'])).decode()):
+                tr_jobs.tr(u"No download necessary for Dataset in cache: {}".format(out_file))
+                do_download = False
+            else:
+                do_download = True
+
+        if do_download:
+            resp = download_result(url['url'], out_file, job,
+                                binascii.hexlify(base64.b64decode(url['md5Hash'])).decode())
+            if not resp:
+                return
 
     create_gee_json_metadata(json_file, job, out_file)
 

--- a/LDMP/main_widget.py
+++ b/LDMP/main_widget.py
@@ -219,7 +219,7 @@ class MainWidget(QtWidgets.QDockWidget, Ui_dockWidget_trends_earth):
             Datasets().triggerDownloads()
 
         # depending on config re-trigger it
-        dataset_refresh_polling_time = QtCore.QSettings().value("trends_earth/advanced/datasets_refresh_polling_time", 60000, type=int)
+        dataset_refresh_polling_time = QtCore.QSettings().value("trends_earth/advanced/datasets_refresh_polling_time", 25000, type=int)
         if autorefresh and dataset_refresh_polling_time > 0:
             QtCore.QTimer.singleShot(dataset_refresh_polling_time, self.refreshDatasets)
 

--- a/LDMP/main_widget.py
+++ b/LDMP/main_widget.py
@@ -187,7 +187,7 @@ class MainWidget(QtWidgets.QDockWidget, Ui_dockWidget_trends_earth):
 
         # show it
 
-    def refreshDatasets(self, autorefresh=True):
+    def refreshDatasets(self, autorefresh=True, autodownload=True):
         """Refresh datasets is composed of the following steps:
         1) Get all executions (e.g. Jobs)
         2) Rebuild and dump Datasets based on the downloaded Jobs
@@ -198,6 +198,11 @@ class MainWidget(QtWidgets.QDockWidget, Ui_dockWidget_trends_earth):
             return
         self.plugin.dlg_jobs.btn_refresh()
         self.updateDatasetsBasedOnJobs()
+
+        # trigger download for terminated jobs
+        dataset_auto_download = QtCore.QSettings().value("trends_earth/advanced/dataset_auto_download", True, type=bool)
+        if autodownload and dataset_auto_download:
+            Datasets().triggerDownloads()
 
         # depending on config re-trigger it
         refresh_polling_time = QtCore.QSettings().value("trends_earth/advanced/refresh_polling_time", 60000, type=int)

--- a/LDMP/main_widget.py
+++ b/LDMP/main_widget.py
@@ -144,7 +144,7 @@ class MainWidget(QtWidgets.QDockWidget, Ui_dockWidget_trends_earth):
         self.pushButton_refresh.clicked.connect(refreshWithotAutorefresh) 
 
         # set automatic refreshes
-        dataset_refresh_polling_time = QtCore.QSettings().value("trends_earth/advanced/datasets_refresh_polling_time", 60000, type=int)
+        dataset_refresh_polling_time = QtCore.QSettings().value("trends_earth/advanced/datasets_refresh_polling_time", 25000, type=int)
         job_refresh_polling_time = QtCore.QSettings().value("trends_earth/advanced/jobs_refresh_polling_time", 60000, type=int)
         if dataset_refresh_polling_time > 0:
             QtCore.QTimer.singleShot(dataset_refresh_polling_time, self.refreshDatasets)
@@ -201,6 +201,11 @@ class MainWidget(QtWidgets.QDockWidget, Ui_dockWidget_trends_earth):
             return
         self.plugin.dlg_jobs.btn_refresh()
         Jobs().sync()
+
+        # depending on config re-trigger it
+        job_refresh_polling_time = QtCore.QSettings().value("trends_earth/advanced/jobs_refresh_polling_time", 60000, type=int)
+        if autorefresh and job_refresh_polling_time > 0:
+            QtCore.QTimer.singleShot(job_refresh_polling_time, self.refreshJobs)
 
     def refreshDatasets(self, autorefresh=True, autodownload=True):
         """Refresh datasets is composed of the following steps:

--- a/LDMP/main_widget.py
+++ b/LDMP/main_widget.py
@@ -137,15 +137,19 @@ class MainWidget(QtWidgets.QDockWidget, Ui_dockWidget_trends_earth):
         self.pushButton_load.clicked.connect(self.loadBaseMap)
 
         # set manual and automatic refresh of datasets
-        # avoid using lambda or partial to allow not anonymous callback => can be remove if necessary
+        # avoid using lambda or partial to allow not anonymous callback => can be removed if necessary
         def refreshWithotAutorefresh():
             self.refreshDatasets(autorefresh=False)
-        self.pushButton_refresh.clicked.connect(refreshWithotAutorefresh)
+            self.refreshJobs(autorefresh=False)
+        self.pushButton_refresh.clicked.connect(refreshWithotAutorefresh) 
 
-        # set automatic refresh
-        refresh_polling_time = QtCore.QSettings().value("trends_earth/advanced/refresh_polling_time", 60000, type=int)
-        if refresh_polling_time > 0:
-            QtCore.QTimer.singleShot(refresh_polling_time, self.refreshDatasets)
+        # set automatic refreshes
+        dataset_refresh_polling_time = QtCore.QSettings().value("trends_earth/advanced/datasets_refresh_polling_time", 60000, type=int)
+        job_refresh_polling_time = QtCore.QSettings().value("trends_earth/advanced/jobs_refresh_polling_time", 60000, type=int)
+        if dataset_refresh_polling_time > 0:
+            QtCore.QTimer.singleShot(dataset_refresh_polling_time, self.refreshDatasets)
+        if job_refresh_polling_time > 0:
+            QtCore.QTimer.singleShot(job_refresh_polling_time, self.refreshJobs)
 
 
         # configure view
@@ -187,16 +191,21 @@ class MainWidget(QtWidgets.QDockWidget, Ui_dockWidget_trends_earth):
 
         # show it
 
-    def refreshDatasets(self, autorefresh=True, autodownload=True):
-        """Refresh datasets is composed of the following steps:
+    def refreshJobs(self, autorefresh=True):
+        """Refresh Jobs is composed of the following steps:
         1) Get all executions (e.g. Jobs)
-        2) Rebuild and dump Datasets based on the downloaded Jobs
         Due to API limitation it's not possible to query a job one by one but only get all jobs in a time window.
         """
-        # use method of toher plgun GUIs to fetch all executions
+        # use method of other plguin GUIs to fetch all executions
         if not self.plugin:
             return
         self.plugin.dlg_jobs.btn_refresh()
+        Jobs().sync()
+
+    def refreshDatasets(self, autorefresh=True, autodownload=True):
+        """Refresh datasets is composed of the following steps:
+        1) Rebuild and dump Datasets based on the downloaded Jobs
+        """
         self.updateDatasetsBasedOnJobs()
 
         # trigger download for terminated jobs
@@ -205,9 +214,9 @@ class MainWidget(QtWidgets.QDockWidget, Ui_dockWidget_trends_earth):
             Datasets().triggerDownloads()
 
         # depending on config re-trigger it
-        refresh_polling_time = QtCore.QSettings().value("trends_earth/advanced/refresh_polling_time", 60000, type=int)
-        if autorefresh and refresh_polling_time > 0:
-            QtCore.QTimer.singleShot(refresh_polling_time, self.refreshDatasets)
+        dataset_refresh_polling_time = QtCore.QSettings().value("trends_earth/advanced/datasets_refresh_polling_time", 60000, type=int)
+        if autorefresh and dataset_refresh_polling_time > 0:
+            QtCore.QTimer.singleShot(dataset_refresh_polling_time, self.refreshDatasets)
 
     def updateDatasetsModel(self):
         datasetsModel = DatasetsModel( Datasets() )  # Datasets is a singleton

--- a/LDMP/models/datasets.py
+++ b/LDMP/models/datasets.py
@@ -395,6 +395,12 @@ class Datasets(QObject):
                     # if strored in datasetStore remove entry related to json_file Dataset
                     self.datasetsStore.pop(json_file, None)
 
+                    # remove also the dataset json that now is nomore necessary
+                    try:
+                        os.remove(json_file)
+                    except:
+                        pass
+
                     log(tr('Dataset {} already downloaded => skipped').format(json_file))
                     continue
 

--- a/LDMP/models/datasets.py
+++ b/LDMP/models/datasets.py
@@ -371,9 +371,15 @@ class Datasets(QObject):
                 #   b4b098f8-e562-4843-b6ed-586878410a01.json
                 # a downloaded dataset could be:
                 #   b4b098f8-e562-4843-b6ed-586878410a01_Productivity 1_0_3_gen_test19.json
-                basename = os.path.basename(json_file)
+                basename = os.path.splitext(os.path.basename(json_file))[0]
                 look_for = basename + "_"
-                if look_for in json_files:
+
+                found = next((j for j in json_files if look_for in j), None) # look if some key containing 'look_for' string
+                if found:
+                    # if strored in datasetStore remove entry related to json_file Dataset
+                    self.datasetsStore.pop(json_file, None)
+
+                    log(tr('Dataset {} already downloaded => skipped').format(json_file))
                     continue
 
                 # block useful to distinguish if dataset is a downloaded dataset or not

--- a/LDMP/models/datasets.py
+++ b/LDMP/models/datasets.py
@@ -222,6 +222,16 @@ class Dataset(DatasetBase):
     def fileName(self):
         return self.__fileName
 
+    @staticmethod
+    def datetimeRepr(dt: datetime) -> str:
+        return datetime.strftime(dt, '%Y/%m/%d (%H:%M)')
+
+    @staticmethod
+    def toDatetime(dt: str, fmt: str = None) -> datetime:
+        if fmt is None:
+            return datetime.fromisoformat(dt)
+        return datetime.strptime(dt, fmt)
+
     def download(self, datasets_refresh: bool = True) -> None:
         """Download Dataset related to a specified Job in a programmatically defined filename and folder.
         Because a new dataset JSON descriptor is created => Datasets sync

--- a/LDMP/models/datasets.py
+++ b/LDMP/models/datasets.py
@@ -262,7 +262,7 @@ class Dataset(DatasetBase):
         log(u"Processing job {}.".format(job.runId))
         result_type = job.results.get('type')
         if result_type == 'CloudResults':
-            download_cloud_results(job.raw, f, self.tr)
+            download_cloud_results(job.raw, f, self.tr, add_to_map=False)
             self.downloaded.emit(f)
             Datasets().sync()
         elif result_type == 'TimeSeriesTable':

--- a/LDMP/models/datasets.py
+++ b/LDMP/models/datasets.py
@@ -14,7 +14,7 @@
 __author__ = 'Luigi Pirelli / Kartoza'
 __date__ = '2021-03-23'
 
-from typing import Optional, Union, List, Dict
+from typing import Optional, Union, List, Dict, Tuple
 from datetime import datetime
 from enum import Enum
 import abc
@@ -24,7 +24,7 @@ from collections import OrderedDict
 
 from qgis.PyQt.QtCore import QSettings, pyqtSignal, QObject
 from qgis.core import QgsLogger
-from LDMP.jobs import Job, JobSchema
+from LDMP.jobs import Job, JobSchema, Jobs, download_cloud_results, download_timeseries
 from LDMP.calculate import get_script_group
 from LDMP import log, singleton, tr, json_serial
 
@@ -91,13 +91,20 @@ class DatasetBase(abc.ABC, QObject, metaclass=FinalMeta):
 class Dataset(DatasetBase):
 
     dumped = pyqtSignal(str)
+    class Origin(Enum):
+        job = 0,
+        dataset = 1,
+        downloaded_dataset = 2,
+        not_applicable = 3
 
     def __init__(self,
             job: Optional[Job] = None,
-            dataset: Optional[Dict] = None
+            dataset: Optional[Dict] = None,
+            filename: Optional[str] = None
         ) -> None:
         super().__init__()
 
+        self.__origin = Dataset.Origin.not_applicable
         if job:
             job_schema = JobSchema()
             self.job = job_schema.dump(job)
@@ -109,18 +116,46 @@ class Dataset(DatasetBase):
             self.name = job.taskName
             self.creation_date = job.startDate
             self.run_id = job.runId
-        elif dataset:
-            self.job = ''
 
-            self.status = dataset.get('status')
-            # self.status: DatasetStatus = getStatusEnum(job.status)
-            self.progress = dataset.get('progress')
-            self.source = dataset.get('source')
-            self.name = dataset.get('name')
-            self.creation_date = dataset.get('creation_date')
-            self.run_id = dataset.get('run_id')
+            self.__origin = Dataset.Origin.job
+            self.__fileName = None
+
+        elif dataset:
+            # check if refer to a Dataset or Downloaded dataset
+            if 'bands' in dataset:
+                self.bands = dataset.get('bands')
+                self.file = dataset.get('file')
+                self.metadata = dataset.get('metadata')
+
+                # set common dataset data get from medatata (e.g. original Job)
+                self.status = self.metadata.get('status')
+                self.progress = self.metadata.get('progress')
+                self.source = self.metadata.get('script_name')
+                self.name = self.metadata.get('task_name')
+                self.creation_date = self.metadata.get('start_date')
+                self.run_id = self.metadata.get('id')
+
+                self.__origin = Dataset.Origin.downloaded_dataset
+                self.__fileName = filename
+
+            else:
+                self.job = ''
+
+                self.status = dataset.get('status')
+                # self.status: DatasetStatus = getStatusEnum(job.status)
+                self.progress = dataset.get('progress')
+                self.source = dataset.get('source')
+                self.name = dataset.get('name')
+                self.creation_date = dataset.get('creation_date')
+                self.run_id = dataset.get('run_id')
+
+                self.__origin = Dataset.Origin.dataset
+                self.__fileName = filename
         else:
             raise Exception('Nor input Job or dataset dictionary are set to build a Dataset instance')
+
+    def origin(self) -> 'Dataset.Origin':
+        return self.__origin
 
     def columnCount(self) -> int:
         return 1
@@ -146,11 +181,12 @@ class Dataset(DatasetBase):
         out_path = os.path.join(base_data_directory, 'ouptuts')
 
         # set location where to save basing on script(alg) used
-        script_name = self.source
-        components = script_name.split()
-        components = components[:-1] if len(components) > 1 else components # eventually remove version that return when get exeutions list
-        formatted_script_name = '-'.join(components) # remove al version and substitutes ' ' with '-'
-        formatted_script_name = formatted_script_name.lower()
+        if self.origin() != Dataset.Origin.downloaded_dataset:
+            script_name = self.source
+            components = script_name.split()
+            components = components[:-1] if len(components) > 1 else components # eventually remove version that return when get exeutions list
+            formatted_script_name = '-'.join(components) # remove al version and substitutes ' ' with '-'
+            formatted_script_name = formatted_script_name.lower()
 
         # get alg group to setup subfolder
         group = get_script_group(formatted_script_name)
@@ -178,7 +214,56 @@ class Dataset(DatasetBase):
                 f, default=json_serial, sort_keys=True, indent=4, separators=(',', ': ')
             )
         self.dumped.emit(descriptor_file_name)
+
+        self.__fileName = descriptor_file_name
         return descriptor_file_name
+
+    def fileName(self):
+        return self.__fileName
+
+    def download(self):
+        """Download Dataset related to a specified Job in a programmatically defined filename and folder.
+        """
+        res = Jobs().jobById(str(self.run_id)) # casting because can be UUID
+        if res is None:
+            log(tr('No Job available in cache with run id: {}').format(str(self.run_id)))
+            return
+        job_filename, job = res # unwrap tuple
+
+        # get path of the current dataset descriptos
+        res = Datasets().datasetById(str(self.run_id)) # casting because can be UUID
+        if res is None:
+            log(tr('No Dataset available in cache with run id: {}').format(str(self.run_id)))
+            return
+        dataset_filename = res[0]
+
+        # Check if we need a download filename - some tasks don't need to 
+        # save data, but if any of the chosen tasks do, then we need to 
+        # choose a folder. Right now only TimeSeriesTable doesn't need a 
+        # filename.
+        base_dir = os.path.dirname(dataset_filename)
+        f = None
+        if job.results.get('type') != 'TimeSeriesTable':
+            # create result filename basing on:
+            # run_id + scriptName + task_name (if any)
+            fileBaseName = None
+            if job.taskName:
+                fileBaseName = u'{}_{}_{}'.format(job.runId, job.scriptName, job.taskName)
+            else:
+                fileBaseName = u'{}_{}_{}'.format(job.runId, job.scriptName)
+            
+            # set the folder where to save result
+            f = os.path.join(base_dir, fileBaseName)
+            log(u"Downloading results to {} with basename {}".format(os.path.dirname(f), os.path.basename(f)))
+
+        log(u"Processing job {}.".format(job.runId))
+        result_type = job.results.get('type')
+        if result_type == 'CloudResults':
+            download_cloud_results(job.raw, f, self.tr)
+        elif result_type == 'TimeSeriesTable':
+            download_timeseries(job.raw, self.tr)
+        else:
+            raise ValueError("Unrecognized result type in download results: {}".format(result_type))
 
 
 @singleton
@@ -261,8 +346,10 @@ class Datasets(QObject):
 
         # remove any previous memorised Datasets
         # self.reset()
-        schema = DatasetSchema()
-        for json_file in traverse(base_data_directory):
+        datasetSchema = DatasetSchema()
+        downloadedDatasetSchema = DownloadedDatasetSchema()
+        json_files = list(traverse(base_data_directory)) # need traverse all to check if some dataset has been already downloaded
+        for json_file in json_files:
             # skip larger thatn 1MB files
             statinfo = os.stat(json_file)
             if statinfo.st_size > 1024*1024:
@@ -276,26 +363,56 @@ class Datasets(QObject):
                     # no json => skip
                     continue
                 except Exception as ex:
-                    log(tr('Error reading file {} with ex: ').format(json_file, str(ex)))
+                    QgsLogger.debug('* Error reading file {} with ex: {}'.format(json_file, str(ex)), debuglevel=3)
                     continue
-            
+
+                # skip if dataset has a downloaded contrepart e.g. a json file with the same UUID plus more
+                # info in filename. e.g if dataset is:
+                #   b4b098f8-e562-4843-b6ed-586878410a01.json
+                # a downloaded dataset could be:
+                #   b4b098f8-e562-4843-b6ed-586878410a01_Productivity 1_0_3_gen_test19.json
+                basename = os.path.basename(json_file)
+                look_for = basename + "_"
+                if look_for in json_files:
+                    continue
+
+                # block useful to distinguish if dataset is a downloaded dataset or not
+                dataset_dict = None
                 try:
-                    dataset_dict = schema.load(parsed_json, partial=True, unknown=marshmallow.INCLUDE)
-                    dataset = Dataset(dataset=dataset_dict)
-                    self.datasetsStore[json_file] = dataset
+                    # check if DownloadedDataset
+                    dataset_dict = downloadedDatasetSchema.load(parsed_json, partial=False, unknown=marshmallow.RAISE)
 
                 except marshmallow.exceptions.ValidationError as ex:
-                    log(tr('not a valid Dataset {} with ex: ').format(f, str(ex)))
-                    continue
+
+                    # now check if a normal Dataset (not yet donwloaded). e.g. previous schema parse failed
+                    try:
+                        dataset_dict = datasetSchema.load(parsed_json, partial=True, unknown=marshmallow.INCLUDE)
+
+                    except marshmallow.exceptions.ValidationError as ex:
+                        log(tr('not a valid Dataset {} with ex: {}').format(f, str(ex)))
+                        continue
+
                 except Exception as ex:
                     # Exception notification managed in append method
                     log(tr('Cannot manage dataset for file {} ex: {}').format(json_file, str(ex)))
                     continue
+                
+                if dataset_dict:
+                    dataset = Dataset(dataset=dataset_dict, filename=json_file)
+                    self.datasetsStore[json_file] = dataset
+
         self.updated.emit()
+
+    def datasetById(self, id: str) -> Optional[Tuple[str, Job]]:
+        """Return Dataset and related descriptor asociated file."""
+        datasets = [(k, d) for k,d in self.datasetsStore.items() if str(d.run_id) == id]
+        return datasets[0] if len(datasets) else None
 
 
 class DatasetSchema(Schema):
     """Schema defining structure of a dumped Dataset.
+    !!! BEAWARE !!! this schema represent only a dataset not yet downloaded.
+    A downloaded dataset has a different schema as described in DownloadedDatasetSchema
     """
     # job = fields.Nested(APIResponseSchema, many=False, required=False)
     job = fields.Str(required=False)
@@ -310,3 +427,19 @@ class DatasetSchema(Schema):
     name = fields.Str()
     creation_date = fields.DateTime(required=True)
     run_id = fields.UUID(required=True)
+
+
+class DownloadedDatasetSchema(Schema):
+    """Schema defining structure of a dounloaded Dataset.
+    !!! BEAWARE !!! this schema represent only a dataset ALREADY downloaded.
+    A "TO DOWNLOAD" dataset has a different schema as described in
+    DatasetSchema
+    """
+    # bands leaved with a fixed schema
+    bands = fields.List(fields.Dict(required=True), required=True)
+
+    file = fields.Str(required=True)
+    metadata = fields.Nested(JobSchema, many=False, required=False)
+
+
+

--- a/LDMP/models/datasets.py
+++ b/LDMP/models/datasets.py
@@ -442,7 +442,7 @@ class Datasets(QObject):
                 continue
             # do not refresh datasets and do only after triggered all downloads
             dataset.download(datasets_refresh=False)
-        self.updated.emit()
+        self.sync()
 
     def datasetById(self, id: str) -> Optional[Tuple[str, Job]]:
         """Return Dataset and related descriptor asociated file."""

--- a/LDMP/models/datasets.py
+++ b/LDMP/models/datasets.py
@@ -268,7 +268,7 @@ class Dataset(DatasetBase):
             if job.taskName:
                 fileBaseName = u'{}_{}_{}'.format(job.runId, job.scriptName, job.taskName)
             else:
-                fileBaseName = u'{}_{}_{}'.format(job.runId, job.scriptName)
+                fileBaseName = u'{}_{}'.format(job.runId, job.scriptName)
             
             # set the folder where to save result
             f = os.path.join(base_dir, fileBaseName)
@@ -483,6 +483,5 @@ class DownloadedDatasetSchema(Schema):
 
     file = fields.Str(required=True)
     metadata = fields.Nested(JobSchema, many=False, required=False)
-
 
 

--- a/LDMP/models/datasets_delegate.py
+++ b/LDMP/models/datasets_delegate.py
@@ -159,7 +159,8 @@ class DatasetEditorWidget(QWidget, Ui_WidgetDatasetItem):
         # disable download button by default
         self.pushButtonStatus.setIcon(QIcon(':/plugins/LDMP/icons/cloud-download.svg'))
         self.pushButtonStatus.setEnabled(False)
-        self.pushButtonStatus.show()
+        dataset_auto_download = QSettings().value("trends_earth/advanced/dataset_auto_download", True, type=bool)
+        self.pushButtonStatus.setHidden(dataset_auto_download)
 
         # show progress bar or download button depending on status
         self.progressBar.setValue(self.dataset.progress)
@@ -183,8 +184,7 @@ class DatasetEditorWidget(QWidget, Ui_WidgetDatasetItem):
             self.progressBar.reset()
             self.progressBar.hide()
             # disable download button if auto download is set
-            dataset_auto_download = QSettings().value("trends_earth/advanced/dataset_auto_download", True, type=bool)
-            self.pushButtonStatus.setEnabled(not dataset_auto_download)
+            self.pushButtonStatus.setEnabled(True)
             # add event to download dataset
             self.pushButtonStatus.clicked.connect(self.dataset.download)
 

--- a/LDMP/models/datasets_delegate.py
+++ b/LDMP/models/datasets_delegate.py
@@ -157,21 +157,31 @@ class DatasetEditorWidget(QWidget, Ui_WidgetDatasetItem):
         self.progressBar.show()
         if self.dataset.status == 'PENDING':
             self.progressBar.setFormat(self.dataset.status)
-        if (self.dataset.progress > 0 and
-            self.dataset.progress < 100):
-           self.progressBar.setFormat(self.dataset.progress)
+        if ( self.dataset.progress > 0 and
+             self.dataset.progress < 100
+            ):
+            self.progressBar.setFormat(self.dataset.progress)
         # change GUI if finished
-        if (self.dataset.status in ['FINISHED', 'SUCCESS'] and
-            self.dataset.progress == 100):
+        if ( self.dataset.status in ['FINISHED', 'SUCCESS'] and
+             self.dataset.progress == 100 and
+             self.dataset.origin() != Dataset.Origin.downloaded_dataset
+            ):
             self.progressBar.hide()
             self.pushButtonStatus.show()
             self.pushButtonStatus.setIcon(QIcon(':/plugins/LDMP/icons/cloud-download.svg'))
+            # add event to download dataset
+            self.pushButtonStatus.clicked.connect(self.dataset.download)
 
         dataset_name = self.dataset.name if self.dataset.name else '<no name set>'
         self.labelDatasetName.setText(dataset_name)
 
         data_source = self.dataset.source if self.dataset.source else 'Unknown'
         self.labelSourceName.setText(self.dataset.source)
+
+        # get data differently if come from Dataset or Downloaded dataset
+        if self.dataset.origin() == Dataset.Origin.downloaded_dataset:
+            self.progressBar.hide()
+            self.pushButtonStatus.hide()
 
     def show_details(self):
         log(f"Details button clicked for dataset {self.dataset.name!r}")

--- a/LDMP/models/datasets_delegate.py
+++ b/LDMP/models/datasets_delegate.py
@@ -144,9 +144,13 @@ class DatasetEditorWidget(QWidget, Ui_WidgetDatasetItem):
             QIcon(':/plugins/LDMP/icons/mActionAddRasterLayer.svg'))
 
         # allow having string or datetime for start_date
+        # setting string in a uniform format
         start_date_txt = self.dataset.creation_date
         if isinstance(self.dataset.creation_date, datetime):
-            start_date_txt = self.dataset.creation_date.strftime('%Y-%m-%d (%H:%M)')
+            start_date_txt = self.dataset.datetimeRepr(self.dataset.creation_date)
+        else:
+            dt = self.dataset.toDatetime(start_date_txt)
+            start_date_txt = self.dataset.datetimeRepr(dt)
         self.labelCreationDate.setText(start_date_txt)
 
         self.labelRunId.setText(str(self.dataset.run_id)) # it is UUID

--- a/LDMP/models/datasets_delegate.py
+++ b/LDMP/models/datasets_delegate.py
@@ -27,7 +27,8 @@ from qgis.PyQt.QtCore import (
     QRectF,
     QRect,
     QAbstractItemModel,
-    QSize
+    QSize,
+    QSettings
 )
 from qgis.PyQt.QtWidgets import (
     QStyleOptionViewItem,
@@ -155,24 +156,35 @@ class DatasetEditorWidget(QWidget, Ui_WidgetDatasetItem):
 
         self.labelRunId.setText(str(self.dataset.run_id)) # it is UUID
 
+        # disable download button by default
+        self.pushButtonStatus.setIcon(QIcon(':/plugins/LDMP/icons/cloud-download.svg'))
+        self.pushButtonStatus.setEnabled(False)
+        self.pushButtonStatus.show()
+
         # show progress bar or download button depending on status
-        self.progressBar.setValue( self.dataset.progress )
-        self.pushButtonStatus.hide()
-        self.progressBar.show()
+        self.progressBar.setValue(self.dataset.progress)
         if self.dataset.status == 'PENDING':
+            self.progressBar.setRange(0,100)
             self.progressBar.setFormat(self.dataset.status)
+            self.progressBar.show()
         if ( self.dataset.progress > 0 and
              self.dataset.progress < 100
             ):
-            self.progressBar.setFormat(self.dataset.progress)
+            # no % come from server => set progress as continue update
+            self.progressBar.show()
+            self.progressBar.setMinimum(0)
+            self.progressBar.setMaximum(0)
+            self.progressBar.setFormat('Processing...')
         # change GUI if finished
         if ( self.dataset.status in ['FINISHED', 'SUCCESS'] and
              self.dataset.progress == 100 and
              self.dataset.origin() != Dataset.Origin.downloaded_dataset
             ):
+            self.progressBar.reset()
             self.progressBar.hide()
-            self.pushButtonStatus.show()
-            self.pushButtonStatus.setIcon(QIcon(':/plugins/LDMP/icons/cloud-download.svg'))
+            # disable download button if auto download is set
+            dataset_auto_download = QSettings().value("trends_earth/advanced/dataset_auto_download", True, type=bool)
+            self.pushButtonStatus.setEnabled(not dataset_auto_download)
             # add event to download dataset
             self.pushButtonStatus.clicked.connect(self.dataset.download)
 


### PR DESCRIPTION
This PR add automatic download of datasets that are in FINISHED or SUCCESS state.
Autodownload can be disabled setting the boolean config parameter:

`trends_earth/advanced/dataset_auto_download`

that is not present is assumed True => auto download
After download download state is updated to the next Dataset refresh from base_data_directory

Downloaded dataset are not downloaded again if already downloaded BTW the original dataset json descriptor is not removed, just ignored is the equivalent downloaded json descriptor is already present.

This PR shoudl fix the following issue/features:
https://github.com/ConservationInternational/trends.earth/issues/376
https://github.com/ConservationInternational/trends.earth/issues/409