### PR TITLE
Datasets filtering

### DIFF
--- a/LDMP/main_widget.py
+++ b/LDMP/main_widget.py
@@ -225,8 +225,15 @@ class MainWidget(QtWidgets.QDockWidget, Ui_dockWidget_trends_earth):
 
     def updateDatasetsModel(self):
         datasetsModel = DatasetsModel( Datasets() )  # Datasets is a singleton
+        # set filtering functionality
+        filter_model = QtCore.QSortFilterProxyModel(Datasets())
+        filter_model.setSourceModel(datasetsModel)
+        filter_model.setFilterKeyColumn(1)
+
+        self.lineEdit_search.valueChanged.connect(filter_model.setFilterFixedString)
+
         self.treeView_datasets.reset()
-        self.treeView_datasets.setModel(datasetsModel)
+        self.treeView_datasets.setModel(filter_model)
 
     def setupAlgorithmsTree(self):
         # setup algorithms and their hierarchy

--- a/LDMP/main_widget.py
+++ b/LDMP/main_widget.py
@@ -35,7 +35,7 @@ from LDMP.models.datasets import (
 from LDMP.models.algorithms_model import AlgorithmTreeModel
 from LDMP.models.algorithms_delegate import AlgorithmItemDelegate
 
-from LDMP.models.datasets_model import DatasetsModel
+from LDMP.models.datasets_model import DatasetsModel, DatasetsSortFilterProxyModel
 from LDMP.models.datasets_delegate import DatasetItemDelegate
 from LDMP import tr
 
@@ -226,14 +226,20 @@ class MainWidget(QtWidgets.QDockWidget, Ui_dockWidget_trends_earth):
     def updateDatasetsModel(self):
         datasetsModel = DatasetsModel( Datasets() )  # Datasets is a singleton
         # set filtering functionality
-        filter_model = QtCore.QSortFilterProxyModel(Datasets())
-        filter_model.setSourceModel(datasetsModel)
-        filter_model.setFilterKeyColumn(1)
+        self.proxy_model = DatasetsSortFilterProxyModel(Datasets())
+        self.proxy_model.setSourceModel(datasetsModel)
 
-        self.lineEdit_search.valueChanged.connect(filter_model.setFilterFixedString)
+        self.lineEdit_search.valueChanged.connect(self.filter_changed)
 
         self.treeView_datasets.reset()
-        self.treeView_datasets.setModel(filter_model)
+        self.treeView_datasets.setModel(self.proxy_model)
+
+    def filter_changed(self, filter_string: str):
+        options = QtCore.QRegularExpression.NoPatternOption
+        options |= QtCore.QRegularExpression.CaseInsensitiveOption
+        regular_expression = QtCore.QRegularExpression(filter_string, options)
+        self.proxy_model.setFilterRegularExpression(regular_expression)
+
 
     def setupAlgorithmsTree(self):
         # setup algorithms and their hierarchy

--- a/LDMP/models/datasets.py
+++ b/LDMP/models/datasets.py
@@ -341,9 +341,6 @@ class Datasets(QObject):
     def columnName(self, column: int) -> Optional[str]:
         return None
 
-    def items(self):
-        return self.datasetsStore.items()
-
     def sync(self):
         """Method to sync with Datasets available in "trends_earth/advanced/base_data_directory".
 

--- a/LDMP/models/datasets.py
+++ b/LDMP/models/datasets.py
@@ -341,6 +341,9 @@ class Datasets(QObject):
     def columnName(self, column: int) -> Optional[str]:
         return None
 
+    def items(self):
+        return self.datasetsStore.items()
+
     def sync(self):
         """Method to sync with Datasets available in "trends_earth/advanced/base_data_directory".
 

--- a/LDMP/models/datasets_delegate.py
+++ b/LDMP/models/datasets_delegate.py
@@ -80,13 +80,13 @@ class DatasetItemDelegate(QStyledItemDelegate):
             return
 
         # activate editor
-        item = model.data(index, Qt.ItemDataRole)
+        item = model.data(index, Qt.DisplayRole)
         self.parent.openPersistentEditor(self.enteredCell)
 
     def paint(self, painter: QPainter, option: QStyleOptionViewItem, index: QModelIndex):
         # get item and manipulate painter basing on idetm data
         model = index.model()
-        item = model.data(index, Qt.ItemDataRole)
+        item = model.data(index, Qt.DisplayRole)
 
         # if a Dataset => show custom widget
         if isinstance(item, Dataset):
@@ -103,7 +103,7 @@ class DatasetItemDelegate(QStyledItemDelegate):
 
     def sizeHint(self, option: QStyleOptionViewItem, index: QModelIndex):
         model = index.model()
-        item = model.data(index, Qt.ItemDataRole)
+        item = model.data(index, Qt.DisplayRole)
 
         if isinstance(item, Dataset):
             widget = self.createEditor(None, option, index) # parent swet to none otherwise remain painted in the widget
@@ -116,7 +116,7 @@ class DatasetItemDelegate(QStyledItemDelegate):
     def createEditor(self, parent: QWidget, option: QStyleOptionViewItem, index: QModelIndex):
         # get item and manipulate painter basing on item data
         model = index.model()
-        item = model.data(index, Qt.ItemDataRole)
+        item = model.data(index, Qt.DisplayRole)
         if isinstance(item, Dataset):
             return DatasetEditorWidget(item, plugin=self.plugin, parent=parent)
         else:

--- a/LDMP/models/datasets_model.py
+++ b/LDMP/models/datasets_model.py
@@ -56,11 +56,7 @@ class DatasetsModel(QAbstractItemModel):
             return None
 
         item = index.internalPointer()
-        if role == Qt.DisplayRole:
-            if index.column() == 0:
-                return list(self.rootItem.items())[index.row()][1]
-
-        if role == Qt.ItemDataRole:
+        if role == Qt.DisplayRole or role == Qt.ItemDataRole:
             return item
 
     def flags(self, index: QModelIndex = QModelIndex()) -> Qt.ItemFlags:

--- a/LDMP/models/datasets_model.py
+++ b/LDMP/models/datasets_model.py
@@ -18,6 +18,7 @@ from typing import Optional
 from qgis.PyQt.QtCore import (
     QAbstractItemModel,
     QModelIndex,
+    QSortFilterProxyModel,
     Qt
 )
 from LDMP.models.datasets import (
@@ -91,3 +92,14 @@ class DatasetsModel(QAbstractItemModel):
             return False
 
         return True
+
+
+class DatasetsSortFilterProxyModel(QSortFilterProxyModel):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+    def filterAcceptsRow(self, source_row: int, source_parent: QModelIndex):
+        index = self.sourceModel().index(source_row, 0, source_parent)
+
+        match = self.filterRegularExpression().match(self.sourceModel().data(index).name)
+        return match.hasMatch()

--- a/LDMP/models/datasets_model.py
+++ b/LDMP/models/datasets_model.py
@@ -25,6 +25,7 @@ from LDMP.models.datasets import (
     Datasets
 )
 
+
 class DatasetsModel(QAbstractItemModel):
 
     def __init__(self, tree: Datasets, parent=None):
@@ -56,7 +57,7 @@ class DatasetsModel(QAbstractItemModel):
         item = index.internalPointer()
         if role == Qt.DisplayRole:
             if index.column() == 0:
-                return list(self.rootItem.items())[index.row()].name
+                return list(self.rootItem.items())[index.row()][1]
 
         if role == Qt.ItemDataRole:
             return item


### PR DESCRIPTION
Fixes https://github.com/ConservationInternational/trends.earth/issues/400

Implements Datasets filtering by adding a custom sort and filtering proxy model, a subclass of  [QSortFilterProxyModel](https://doc.qt.io/qt-5/qsortfilterproxymodel.html), the subclass handles a different filtering mechanism compared to its superclass as in our case we need to filter data from Dataset class.

I have updated the model item access in the `DatasetItemDelegate` to use `Qt.DisplayRole` instead of `Qt.ItemDataRole` because the [QSortFilterProxyModel](https://doc.qt.io/qt-5/qsortfilterproxymodel.html) only support the former.

The filtering is case insensitive.

screenshot showing Datasets filtering in action
![filtering_datasets](https://user-images.githubusercontent.com/2663775/118051427-abd9c800-b389-11eb-9418-5f2b8374fb14.gif)
