### PR TITLE
Datasets sorting

### DIFF
--- a/LDMP/gui/WidgetMain.ui
+++ b/LDMP/gui/WidgetMain.ui
@@ -86,6 +86,13 @@ for running algorithms and their results.</string>
             </property>
            </widget>
           </item>
+          <item>
+           <widget class="QCheckBox" name="reverse_box">
+            <property name="text">
+             <string>Reverse</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </item>
         <item>

--- a/LDMP/main_widget.py
+++ b/LDMP/main_widget.py
@@ -159,6 +159,7 @@ class MainWidget(QtWidgets.QDockWidget, Ui_dockWidget_trends_earth):
 
         for field_type, text in sort_fields.items():
             sort_action = QtWidgets.QAction(tr(text), self)
+            sort_action.setData(field_type)
             sort_datasets = partial(self.sort_datasets, sort_action, field_type)
             sort_action.triggered.connect(sort_datasets)
             self.toolButton_sort.menu().addAction(sort_action)
@@ -278,6 +279,8 @@ class MainWidget(QtWidgets.QDockWidget, Ui_dockWidget_trends_earth):
 
         self.treeView_datasets.reset()
         self.treeView_datasets.setModel(self.proxy_model)
+        self.sort_datasets(self.toolButton_sort.defaultAction(),
+                           self.toolButton_sort.defaultAction().data())
 
     def filter_changed(self, filter_string: str):
         options = QtCore.QRegularExpression.NoPatternOption

--- a/LDMP/main_widget.py
+++ b/LDMP/main_widget.py
@@ -272,13 +272,12 @@ class MainWidget(QtWidgets.QDockWidget, Ui_dockWidget_trends_earth):
         # set filtering functionality
         self.proxy_model = DatasetsSortFilterProxyModel(Datasets())
         self.proxy_model.setSourceModel(datasetsModel)
-        self.proxy_model.layoutChanged.connect(self.clear_message_bar)
+        self.proxy_model.layoutChanged.connect(self.model_layout_changed)
 
         self.lineEdit_search.valueChanged.connect(self.filter_changed)
 
         self.treeView_datasets.reset()
         self.treeView_datasets.setModel(self.proxy_model)
-        self.toolButton_sort.defaultAction().trigger()
 
     def filter_changed(self, filter_string: str):
         options = QtCore.QRegularExpression.NoPatternOption
@@ -287,28 +286,13 @@ class MainWidget(QtWidgets.QDockWidget, Ui_dockWidget_trends_earth):
         self.proxy_model.setFilterRegularExpression(regular_expression)
 
     def sort_datasets(self, action: QtWidgets.QAction, field: SortField):
-        # Show sorting progress, some Datasets takes a bit long to sort
-        #self.add_sort_filter_progress(tr("Sorting Datasets..."))
         self.toolButton_sort.setDefaultAction(action)
-        self.proxy_model.setDatasetSortField(field)
+        self.toolButton_sort.setEnabled(False)
         order = QtCore.Qt.AscendingOrder if not self.reverse_box.isChecked() else QtCore.Qt.DescendingOrder
-        self.proxy_model.sort(0, order)
+        self.proxy_model.sort(0, order, field)
 
-    def add_sort_filter_progress(self, message):
-        self.message_bar_sort_filter = MessageBar().get().createMessage(message)
-        progress_bar = QtWidgets.QProgressBar()
-        progress_bar.setAlignment(QtCore.Qt.AlignLeft | QtCore.Qt.AlignVCenter)
-        progress_bar.setMinimum(0)
-        progress_bar.setMaximum(0)
-        self.message_bar_sort_filter.layout().addWidget(progress_bar)
-        MessageBar().get().pushWidget(self.message_bar_sort_filter, Qgis.Info)
-
-    def clear_message_bar(self):
-        # Using try and catch block message bar item might be already deleted.
-        try:
-            MessageBar().get().popWidget(self.message_bar_sort_filter)
-        except RuntimeError:
-            pass
+    def model_layout_changed(self):
+        self.toolButton_sort.setEnabled(True)
 
     def setupAlgorithmsTree(self):
         # setup algorithms and their hierarchy

--- a/LDMP/main_widget.py
+++ b/LDMP/main_widget.py
@@ -38,7 +38,8 @@ from LDMP.models.datasets import (
 from LDMP.models.algorithms_model import AlgorithmTreeModel
 from LDMP.models.algorithms_delegate import AlgorithmItemDelegate
 
-from LDMP.models.datasets_model import DatasetsModel, DatasetsSortFilterProxyModel, SortField
+from LDMP.models.datasets_model import DatasetsModel, DatasetsSortFilterProxyModel
+from LDMP.models.datasets import SortField
 from LDMP.models.datasets_delegate import DatasetItemDelegate
 from LDMP import tr
 
@@ -287,7 +288,7 @@ class MainWidget(QtWidgets.QDockWidget, Ui_dockWidget_trends_earth):
 
     def sort_datasets(self, action: QtWidgets.QAction, field: SortField):
         # Show sorting progress, some Datasets takes a bit long to sort
-        self.add_sort_filter_progress(tr("Sorting Datasets..."))
+        #self.add_sort_filter_progress(tr("Sorting Datasets..."))
         self.toolButton_sort.setDefaultAction(action)
         self.proxy_model.setDatasetSortField(field)
         order = QtCore.Qt.AscendingOrder if not self.reverse_box.isChecked() else QtCore.Qt.DescendingOrder

--- a/LDMP/main_widget.py
+++ b/LDMP/main_widget.py
@@ -289,6 +289,7 @@ class MainWidget(QtWidgets.QDockWidget, Ui_dockWidget_trends_earth):
         self.toolButton_sort.setDefaultAction(action)
         self.toolButton_sort.setEnabled(False)
         order = QtCore.Qt.AscendingOrder if not self.reverse_box.isChecked() else QtCore.Qt.DescendingOrder
+        self.treeView_datasets.reset()
         self.proxy_model.sort(0, order, field)
 
     def model_layout_changed(self):

--- a/LDMP/models/datasets.py
+++ b/LDMP/models/datasets.py
@@ -597,7 +597,7 @@ class Datasets(QObject):
     def __less_than(self, left_dataset, right_dataset, field: SortField):
         if field == SortField.NAME:
             if left_dataset.name != right_dataset.name:
-                return left_dataset.name <= right_dataset.name
+                return left_dataset.name < right_dataset.name
         elif field == SortField.DATE:
             return self.__compare_dates(
                 left_dataset.creation_date,
@@ -605,10 +605,10 @@ class Datasets(QObject):
             )
         elif field == SortField.ALGORITHM:
             if left_dataset.source != right_dataset.source:
-                return left_dataset.source <= right_dataset.source
+                return left_dataset.source < right_dataset.source
         elif field == SortField.STATUS:
             if left_dataset.status != right_dataset.status:
-                return left_dataset.status <= right_dataset.status
+                return left_dataset.status < right_dataset.status
 
         return self.__compare_dates(
             left_dataset.creation_date,

--- a/LDMP/models/datasets.py
+++ b/LDMP/models/datasets.py
@@ -596,16 +596,36 @@ class Datasets(QObject):
 
     def __less_than(self, left_dataset, right_dataset, field: SortField):
         if field == SortField.NAME:
-            return left_dataset.name <= right_dataset.name
-        elif field == SortField.DATE and \
-                isinstance(left_dataset.creation_date, datetime) \
-                and isinstance(right_dataset.creation_date, datetime):
-            return left_dataset.creation_date <= right_dataset.creation_date
+            if left_dataset.name != right_dataset.name:
+                return left_dataset.name <= right_dataset.name
+        elif field == SortField.DATE:
+            return self.__compare_dates(
+                left_dataset.creation_date,
+                right_dataset.creation_date
+            )
         elif field == SortField.ALGORITHM:
-            return left_dataset.source <= right_dataset.source
+            if left_dataset.source != right_dataset.source:
+                return left_dataset.source <= right_dataset.source
         elif field == SortField.STATUS:
-            return left_dataset.status <= right_dataset.status
-        return False
+            if left_dataset.status != right_dataset.status:
+                return left_dataset.status <= right_dataset.status
+
+        return self.__compare_dates(
+            left_dataset.creation_date,
+            right_dataset.creation_date
+        )
+
+    def __compare_dates(self, left, right):
+
+        if isinstance(left, datetime) and isinstance(right, str):
+            right = datetime.fromisoformat(right)
+        elif isinstance(left, str) and isinstance(right, datetime):
+            left = datetime.fromisoformat(left)
+        elif isinstance(left, str) and isinstance(right, str):
+            left = datetime.fromisoformat(left)
+            right = datetime.fromisoformat(right)
+
+        return left <= right
 
 
 class DatasetSchema(Schema):

--- a/LDMP/models/datasets.py
+++ b/LDMP/models/datasets.py
@@ -559,13 +559,13 @@ class Datasets(QObject):
              order: Qt.SortOrder = Qt.AscendingOrder,
              field: SortField = SortField.DATE
              ):
-        self.datasetsStore = OrderedDict(
-            self.__merge_sort(
+        sorted_items = self.__merge_sort(
                 list(self.datasetsStore.items()),
                 order,
                 field
             )
-        )
+        if sorted_items is not None:
+            self.datasetsStore = OrderedDict(sorted_items)
 
     def __merge_sort(self, items: List, order, field: SortField):
         if len(items) <= 1:
@@ -583,7 +583,8 @@ class Datasets(QObject):
 
         while i < len(left) and j < len(right):
             condition = self.__less_than(left[i][1], right[j][1], field)
-            if condition ^ (order is Qt.DescendingOrder):
+            condition = condition if order is Qt.AscendingOrder else not condition
+            if condition:
                 sorted_dict.append(left[i])
                 i += 1
             else:
@@ -595,15 +596,15 @@ class Datasets(QObject):
 
     def __less_than(self, left_dataset, right_dataset, field: SortField):
         if field == SortField.NAME:
-            return left_dataset.name < right_dataset.name
+            return left_dataset.name <= right_dataset.name
         elif field == SortField.DATE and \
                 isinstance(left_dataset.creation_date, datetime) \
                 and isinstance(right_dataset.creation_date, datetime):
-            return left_dataset.creation_date < right_dataset.creation_date
+            return left_dataset.creation_date <= right_dataset.creation_date
         elif field == SortField.ALGORITHM:
-            return left_dataset.source < right_dataset.source
+            return left_dataset.source <= right_dataset.source
         elif field == SortField.STATUS:
-            return left_dataset.status < right_dataset.status
+            return left_dataset.status <= right_dataset.status
         return False
 
 

--- a/LDMP/models/datasets.py
+++ b/LDMP/models/datasets.py
@@ -619,10 +619,9 @@ class Datasets(QObject):
 
         if isinstance(left, datetime) and isinstance(right, str):
             right = datetime.fromisoformat(right)
-        elif isinstance(left, str) and isinstance(right, datetime):
+        if isinstance(left, str):
             left = datetime.fromisoformat(left)
-        elif isinstance(left, str) and isinstance(right, str):
-            left = datetime.fromisoformat(left)
+        if isinstance(right, str):
             right = datetime.fromisoformat(right)
 
         return left <= right

--- a/LDMP/models/datasets_model.py
+++ b/LDMP/models/datasets_model.py
@@ -27,15 +27,9 @@ from qgis.PyQt.QtCore import (
 )
 from LDMP.models.datasets import (
     Dataset,
-    Datasets
+    Datasets,
+    SortField
 )
-
-
-class SortField(enum.Enum):
-    NAME = 'name'
-    DATE = 'date'
-    ALGORITHM = 'algorithm'
-    STATUS = 'status'
 
 
 class DatasetsModel(QAbstractItemModel):
@@ -100,6 +94,9 @@ class DatasetsModel(QAbstractItemModel):
 
         return True
 
+    def rootModel(self):
+        return self.rootItem
+
 
 class DatasetsSortFilterProxyModel(QSortFilterProxyModel):
     def __init__(self, parent=None):
@@ -130,3 +127,6 @@ class DatasetsSortFilterProxyModel(QSortFilterProxyModel):
 
     def setDatasetSortField(self, field: SortField):
         self.dataset_sort_field = field
+
+    def sort(self, column: int, order):
+        self.sourceModel().rootModel().sort(column, order, self.dataset_sort_field)

--- a/LDMP/models/datasets_model.py
+++ b/LDMP/models/datasets_model.py
@@ -101,7 +101,6 @@ class DatasetsModel(QAbstractItemModel):
 class DatasetsSortFilterProxyModel(QSortFilterProxyModel):
     def __init__(self, parent=None):
         super().__init__(parent)
-        self.dataset_sort_field = SortField.DATE
 
     def filterAcceptsRow(self, source_row: int, source_parent: QModelIndex):
         index = self.sourceModel().index(source_row, 0, source_parent)
@@ -109,24 +108,7 @@ class DatasetsSortFilterProxyModel(QSortFilterProxyModel):
         match = self.filterRegularExpression().match(self.sourceModel().data(index).name)
         return match.hasMatch()
 
-    def lessThan(self, left: QModelIndex, right: QModelIndex):
-        left_dataset = self.sourceModel().data(left)
-        right_dataset = self.sourceModel().data(right)
-
-        if self.dataset_sort_field == SortField.NAME:
-            return left_dataset.name < right_dataset.name
-        elif self.dataset_sort_field == SortField.DATE and \
-                isinstance(left_dataset.creation_date, datetime) \
-                and isinstance(right_dataset.creation_date, datetime):
-            return left_dataset.creation_date < right_dataset.creation_date
-        elif self.dataset_sort_field == SortField.ALGORITHM:
-            return left_dataset.source < right_dataset.source
-        elif self.dataset_sort_field == SortField.STATUS:
-            return left_dataset.status < right_dataset.status
-        return False
-
-    def setDatasetSortField(self, field: SortField):
-        self.dataset_sort_field = field
-
-    def sort(self, column: int, order):
-        self.sourceModel().rootModel().sort(column, order, self.dataset_sort_field)
+    def sort(self, column: int, order, field: SortField = None):
+        if field is not None:
+            self.sourceModel().rootModel().sort(order, field)
+            self.layoutChanged.emit()


### PR DESCRIPTION
Fixes https://github.com/ConservationInternational/trends.earth/issues/401
Contains work from https://github.com/ConservationInternational/trends.earth/pull/423

Adds sorting functionality on the existing Datasets sort and filter proxy model, added a new Reverse checkbox that when checked the Datasets will be sorted in descending order. By default the sort in by creation date

I have added a progress message bar to notify user when Datasets sorting, this is useful when sorting take a bit long.
When datasets are refreshed and newer datasets have been added to the source model, they are automatically sorted by Date.

[**Updated**] Screenshot of sorting datasets example
![updated_sorting](https://user-images.githubusercontent.com/2663775/118795859-b4f3f900-b8a3-11eb-9dbc-77d06ecd564a.gif)
