### PR TITLE
Update algorithm run button

### DIFF
--- a/LDMP/gui/WidgetAlgorithmLeaf.ui
+++ b/LDMP/gui/WidgetAlgorithmLeaf.ui
@@ -79,7 +79,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1">
+    <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,1">
      <item>
       <widget class="QLabel" name="labelAlgorithmName">
        <property name="text">
@@ -91,7 +91,44 @@
       </widget>
      </item>
      <item>
+      <widget class="QPushButton" name="pushButton">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>200</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QToolButton" name="toolButtonAlgorithmRun">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>200</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="text">
         <string>...</string>
        </property>


### PR DESCRIPTION
Fixes https://github.com/ConservationInternational/trends.earth/issues/398
Updates the algorithm run button to change according to the algorithm run mode state. 

Screenshot showing how run buttons will look accordingly to the respective algorithm run mode, the Land productivity algorithm
has been set to local and remote run modes for testing purposes.
![update_alg_run_button](https://user-images.githubusercontent.com/2663775/118398555-d5cd0c00-b661-11eb-9702-a6c7245c8297.gif)
