### PR TITLE
Fix download data dialogue

### DIFF
--- a/LDMP/calculate.py
+++ b/LDMP/calculate.py
@@ -41,6 +41,7 @@ from . import (
 )
 from .algorithms import models
 from .conf import (
+    REMOTE_DATASETS,
     Setting,
     settings_manager,
 )
@@ -521,10 +522,7 @@ class DlgCalculateBase(QtWidgets.QDialog):
                                'data', 'scripts.json')) as script_file:
             self.scripts = json.load(script_file)
 
-        with open(os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                               'data', 'gee_datasets.json')) as datasets_file:
-            self.datasets = json.load(datasets_file)
-
+        self.datasets = REMOTE_DATASETS
         self.firstShowEvent.connect(self.firstShow)
 
     def toggle_execution_button(self, enabled: bool):

--- a/LDMP/gui/DlgDownload.ui
+++ b/LDMP/gui/DlgDownload.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>642</width>
-    <height>337</height>
+    <width>1011</width>
+    <height>542</height>
    </rect>
   </property>
   <property name="sizePolicy">


### PR DESCRIPTION
This PR reinstates the download of remote data which had gotten broken since some commits back, when merging the new algorithm execution dialogues