### PR TITLE
Use qregexp in order to support older qt versions

### DIFF
--- a/LDMP/gui/DlgCalculateLC.ui
+++ b/LDMP/gui/DlgCalculateLC.ui
@@ -43,11 +43,44 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>430</width>
+         <width>395</width>
          <height>479</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <item>
+           <widget class="QLabel" name="region_la">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="toolTip">
+             <string>The current selected region of interest</string>
+            </property>
+            <property name="text">
+             <string>region name</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="region_button">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Opens settings dialog in order to change region of interest.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Change region</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
         <item>
          <widget class="QLabel" name="execution_name_la">
           <property name="sizePolicy">
@@ -56,13 +89,20 @@
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
+          <property name="toolTip">
+           <string>Input the name that will be assigned to the execution task.</string>
+          </property>
           <property name="text">
            <string>Execution name:</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QLineEdit" name="execution_name_le"/>
+         <widget class="QLineEdit" name="execution_name_le">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Input for the name that will be assigned to the execution task, if not filled the algorithm name will be used as the task name.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+         </widget>
         </item>
         <item>
          <widget class="QLabel" name="task_notes_la">
@@ -97,40 +137,10 @@
             <height>100</height>
            </size>
           </property>
+          <property name="toolTip">
+           <string>User notes associated with the executed task.</string>
+          </property>
          </widget>
-        </item>
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout">
-          <item>
-           <widget class="QLabel" name="region_la">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="toolTip">
-             <string>The current selected region of interest</string>
-            </property>
-            <property name="text">
-             <string>region name</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="region_button">
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Opens settings dialog in order to change region of interest.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="text">
-             <string>Change region</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
         </item>
         <item>
          <widget class="QgsCollapsibleGroupBox" name="advanced_configurations">

--- a/LDMP/gui/DlgCalculateLDNSummaryTableAdmin.ui
+++ b/LDMP/gui/DlgCalculateLDNSummaryTableAdmin.ui
@@ -413,7 +413,7 @@
              <item>
               <widget class="QPushButton" name="region_button">
                <property name="toolTip">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Opens settings dialog in order to change region of interest.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Opens settings dialog in order to change region of interest.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                </property>
                <property name="text">
                 <string>Change region</string>
@@ -430,7 +430,11 @@
             </widget>
            </item>
            <item>
-            <widget class="QLineEdit" name="execution_name_le"/>
+            <widget class="QLineEdit" name="execution_name_le">
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Input for the name that will be assigned to the execution task, if not filled the algorithm name will be used as the task name.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+            </widget>
            </item>
            <item>
             <widget class="QLabel" name="task_notes_la">
@@ -458,6 +462,9 @@
                <width>16777215</width>
                <height>100</height>
               </size>
+             </property>
+             <property name="toolTip">
+              <string>User notes associated with the executed task.</string>
              </property>
             </widget>
            </item>
@@ -524,7 +531,7 @@ p, li { white-space: pre-wrap; }
   <customwidget>
    <class>WidgetDataIOSelectTELayerImport</class>
    <extends>QComboBox</extends>
-   <header>LDMP/data_io.h</header>
+   <header>LDMP/data_io</header>
   </customwidget>
   <customwidget>
    <class>WidgetDataIOSelectTELayerExisting</class>

--- a/LDMP/gui/DlgCalculateOneStep.ui
+++ b/LDMP/gui/DlgCalculateOneStep.ui
@@ -19,6 +19,9 @@
   <property name="windowTitle">
    <string>SDG 15.3.1 Indicator (one-step) | Land Degradation</string>
   </property>
+  <property name="toolTip">
+   <string>User notes associated with the executed task.</string>
+  </property>
   <layout class="QVBoxLayout" name="verticalLayout_6">
    <item>
     <widget class="QSplitter" name="splitter">
@@ -148,6 +151,9 @@
                      <height>35</height>
                     </size>
                    </property>
+                   <property name="toolTip">
+                    <string>Select the final year, should be great than the initial year</string>
+                   </property>
                    <property name="displayFormat">
                     <string notr="true">yyyy</string>
                    </property>
@@ -179,6 +185,9 @@
                      <width>120</width>
                      <height>35</height>
                     </size>
+                   </property>
+                   <property name="toolTip">
+                    <string>Select the initial year, should be less than the final year.</string>
                    </property>
                    <property name="displayFormat">
                     <string notr="true">yyyy</string>
@@ -254,7 +263,7 @@
              <item>
               <widget class="QPushButton" name="region_button">
                <property name="toolTip">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Opens settings dialog in order to change region of interest.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Opens settings dialog in order to change region of interest.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                </property>
                <property name="text">
                 <string>Change region</string>
@@ -271,7 +280,11 @@
             </widget>
            </item>
            <item>
-            <widget class="QLineEdit" name="execution_name_le"/>
+            <widget class="QLineEdit" name="execution_name_le">
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Input for the name that will be assigned to the execution task, if not filled the algorithm name will be used as the task name.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+            </widget>
            </item>
            <item>
             <widget class="QLabel" name="task_notes_la">
@@ -300,6 +313,9 @@
                <height>100</height>
               </size>
              </property>
+             <property name="toolTip">
+              <string>User notes associated with the executed task.</string>
+             </property>
             </widget>
            </item>
            <item>
@@ -308,7 +324,7 @@
               <string>Advanced configuration</string>
              </property>
              <property name="collapsed">
-              <bool>false</bool>
+              <bool>true</bool>
              </property>
              <layout class="QVBoxLayout" name="verticalLayout_5">
               <item>

--- a/LDMP/gui/DlgCalculateProd.ui
+++ b/LDMP/gui/DlgCalculateProd.ui
@@ -185,6 +185,9 @@
                      <height>40</height>
                     </size>
                    </property>
+                   <property name="toolTip">
+                    <string>Select the type of the NDVI dataset.</string>
+                   </property>
                   </widget>
                  </item>
                 </layout>
@@ -220,7 +223,7 @@
              <item>
               <widget class="QPushButton" name="region_button">
                <property name="toolTip">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Opens settings dialog in order to change region of interest.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Opens settings dialog in order to change region of interest.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                </property>
                <property name="text">
                 <string>Change region</string>
@@ -237,7 +240,11 @@
             </widget>
            </item>
            <item>
-            <widget class="QLineEdit" name="execution_name_le"/>
+            <widget class="QLineEdit" name="execution_name_le">
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Input for the name that will be assigned to the execution task, if not filled the algorithm name will be used as the task name.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+            </widget>
            </item>
            <item>
             <widget class="QLabel" name="task_notes_la">
@@ -265,6 +272,9 @@
                <width>16777215</width>
                <height>100</height>
               </size>
+             </property>
+             <property name="toolTip">
+              <string>User notes associated with the executed task.</string>
              </property>
             </widget>
            </item>
@@ -1000,7 +1010,7 @@ p, li { white-space: pre-wrap; }
   <customwidget>
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>
-   <header>qgis.gui</header>
+   <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/LDMP/gui/DlgCalculateRestBiomassData.ui
+++ b/LDMP/gui/DlgCalculateRestBiomassData.ui
@@ -183,7 +183,7 @@
              <item>
               <widget class="QPushButton" name="region_button">
                <property name="toolTip">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Opens settings dialog in order to change region of interest.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Opens settings dialog in order to change region of interest.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                </property>
                <property name="text">
                 <string>Change region</string>
@@ -200,7 +200,11 @@
             </widget>
            </item>
            <item>
-            <widget class="QLineEdit" name="execution_name_le"/>
+            <widget class="QLineEdit" name="execution_name_le">
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Input for the name that will be assigned to the execution task, if not filled the algorithm name will be used as the task name.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+            </widget>
            </item>
            <item>
             <widget class="QLabel" name="task_notes_la">
@@ -228,6 +232,9 @@
                <width>16777215</width>
                <height>100</height>
               </size>
+             </property>
+             <property name="toolTip">
+              <string>User notes associated with the executed task.</string>
              </property>
             </widget>
            </item>

--- a/LDMP/gui/DlgCalculateRestBiomassSummaryTable.ui
+++ b/LDMP/gui/DlgCalculateRestBiomassSummaryTable.ui
@@ -122,6 +122,9 @@
                      <height>30</height>
                     </size>
                    </property>
+                   <property name="toolTip">
+                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select the biomass dataset to be used for the biomass change calculations.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                   </property>
                    <property name="layer_type" stdset="0">
                     <string notr="true">Biomass (tonnes CO2e per ha)</string>
                    </property>
@@ -160,7 +163,7 @@
              <item>
               <widget class="QPushButton" name="region_button">
                <property name="toolTip">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Opens settings dialog in order to change region of interest.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Opens settings dialog in order to change region of interest.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                </property>
                <property name="text">
                 <string>Change region</string>
@@ -177,7 +180,11 @@
             </widget>
            </item>
            <item>
-            <widget class="QLineEdit" name="execution_name_le"/>
+            <widget class="QLineEdit" name="execution_name_le">
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Input for the name that will be assigned to the execution task, if not filled the algorithm name will be used as the task name.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+            </widget>
            </item>
            <item>
             <widget class="QLabel" name="task_notes_la">
@@ -205,6 +212,9 @@
                <width>16777215</width>
                <height>100</height>
               </size>
+             </property>
+             <property name="toolTip">
+              <string>User notes associated with the executed task.</string>
              </property>
             </widget>
            </item>

--- a/LDMP/gui/DlgCalculateSOC.ui
+++ b/LDMP/gui/DlgCalculateSOC.ui
@@ -56,6 +56,9 @@
        </property>
        <item>
         <widget class="QScrollArea" name="scrollArea">
+         <property name="toolTip">
+          <string>Input for the name that will be assigned to the execution task, if not filled the algorithm name will be used as the task name.</string>
+         </property>
          <property name="horizontalScrollBarPolicy">
           <enum>Qt::ScrollBarAlwaysOff</enum>
          </property>
@@ -79,45 +82,6 @@
              </property>
              <property name="frameShadow">
               <enum>QFrame::Raised</enum>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="execution_name_la">
-             <property name="text">
-              <string>Execution name:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLineEdit" name="execution_name_le"/>
-           </item>
-           <item>
-            <widget class="QLabel" name="task_notes_la">
-             <property name="text">
-              <string>Notes:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QTextEdit" name="task_notes">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize">
-              <size>
-               <width>0</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>100</height>
-              </size>
              </property>
             </widget>
            </item>
@@ -148,7 +112,7 @@
              <item>
               <widget class="QPushButton" name="region_button">
                <property name="toolTip">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Opens settings dialog in order to change region of interest.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Opens settings dialog in order to change region of interest.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                </property>
                <property name="text">
                 <string>Change region</string>
@@ -156,6 +120,52 @@
               </widget>
              </item>
             </layout>
+           </item>
+           <item>
+            <widget class="QLabel" name="execution_name_la">
+             <property name="text">
+              <string>Execution name:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLineEdit" name="execution_name_le">
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Input for the name that will be assigned to the execution task,if not filled the algorithm name will be used as the task name.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="task_notes_la">
+             <property name="text">
+              <string>Notes:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QTextEdit" name="task_notes">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>100</height>
+              </size>
+             </property>
+             <property name="toolTip">
+              <string>User notes associated with the executed task.</string>
+             </property>
+            </widget>
            </item>
            <item>
             <widget class="QgsCollapsibleGroupBox" name="advance_configurations">

--- a/LDMP/gui/DlgCalculateTCData.ui
+++ b/LDMP/gui/DlgCalculateTCData.ui
@@ -63,7 +63,7 @@
           <property name="geometry">
            <rect>
             <x>0</x>
-            <y>-258</y>
+            <y>0</y>
             <width>690</width>
             <height>996</height>
            </rect>
@@ -84,6 +84,19 @@
                  <string>Period</string>
                 </property>
                 <layout class="QGridLayout" name="gridLayout_9">
+                 <item row="1" column="1">
+                  <widget class="QLabel" name="label_4">
+                   <property name="minimumSize">
+                    <size>
+                     <width>0</width>
+                     <height>30</height>
+                    </size>
+                   </property>
+                   <property name="text">
+                    <string>Target year:</string>
+                   </property>
+                  </widget>
+                 </item>
                  <item row="2" column="1">
                   <widget class="QDateEdit" name="hansen_tg_year">
                    <property name="sizePolicy">
@@ -103,6 +116,9 @@
                      <width>120</width>
                      <height>35</height>
                     </size>
+                   </property>
+                   <property name="toolTip">
+                    <string>Select the target year, should be great than the initial year</string>
                    </property>
                    <property name="minimumDateTime">
                     <datetime>
@@ -159,16 +175,13 @@
                    </property>
                   </widget>
                  </item>
-                 <item row="1" column="1">
-                  <widget class="QLabel" name="label_4">
-                   <property name="minimumSize">
-                    <size>
-                     <width>0</width>
-                     <height>30</height>
-                    </size>
-                   </property>
+                 <item row="0" column="0">
+                  <widget class="QRadioButton" name="use_hansen">
                    <property name="text">
-                    <string>Target year:</string>
+                    <string>Hansen et. al. Global Forest Change product (30 m resolution)</string>
+                   </property>
+                   <property name="checked">
+                    <bool>true</bool>
                    </property>
                   </widget>
                  </item>
@@ -191,6 +204,9 @@
                      <width>120</width>
                      <height>35</height>
                     </size>
+                   </property>
+                   <property name="toolTip">
+                    <string>Select the initial year, should be less than the final year.</string>
                    </property>
                    <property name="maximumDate">
                     <date>
@@ -215,16 +231,6 @@
                      <month>1</month>
                      <day>1</day>
                     </date>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="0">
-                  <widget class="QRadioButton" name="use_hansen">
-                   <property name="text">
-                    <string>Hansen et. al. Global Forest Change product (30 m resolution)</string>
-                   </property>
-                   <property name="checked">
-                    <bool>true</bool>
                    </property>
                   </widget>
                  </item>
@@ -382,7 +388,7 @@
              <item>
               <widget class="QPushButton" name="region_button">
                <property name="toolTip">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Opens settings dialog in order to change region of interest.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Opens settings dialog in order to change region of interest.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                </property>
                <property name="text">
                 <string>Change region</string>
@@ -399,7 +405,11 @@
             </widget>
            </item>
            <item>
-            <widget class="QLineEdit" name="execution_name_le"/>
+            <widget class="QLineEdit" name="execution_name_le">
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Input for the name that will be assigned to the execution task, if not filled the algorithm name will be used as the task name.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+            </widget>
            </item>
            <item>
             <widget class="QLabel" name="task_notes_la">
@@ -427,6 +437,9 @@
                <width>16777215</width>
                <height>100</height>
               </size>
+             </property>
+             <property name="toolTip">
+              <string>User notes associated with the executed task.</string>
              </property>
             </widget>
            </item>
@@ -613,7 +626,7 @@ p, li { white-space: pre-wrap; }
   <customwidget>
    <class>WidgetDataIOSelectTELayerImport</class>
    <extends>QComboBox</extends>
-   <header>LDMP/data_io.h</header>
+   <header>LDMP/data_io</header>
   </customwidget>
   <customwidget>
    <class>WidgetDataIOSelectTELayerExisting</class>

--- a/LDMP/gui/DlgCalculateTCSummaryTable.ui
+++ b/LDMP/gui/DlgCalculateTCSummaryTable.ui
@@ -209,7 +209,7 @@
              <item>
               <widget class="QPushButton" name="region_button">
                <property name="toolTip">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Opens settings dialog in order to change region of interest.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Opens settings dialog in order to change region of interest.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                </property>
                <property name="text">
                 <string>Change region</string>
@@ -226,7 +226,11 @@
             </widget>
            </item>
            <item>
-            <widget class="QLineEdit" name="execution_name_le"/>
+            <widget class="QLineEdit" name="execution_name_le">
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Input for the name that will be assigned to the execution task, if not filled the algorithm name will be used as the task name.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+            </widget>
            </item>
            <item>
             <widget class="QLabel" name="task_notes_la">
@@ -254,6 +258,9 @@
                <width>16777215</width>
                <height>100</height>
               </size>
+             </property>
+             <property name="toolTip">
+              <string>User notes associated with the executed task.</string>
              </property>
             </widget>
            </item>

--- a/LDMP/gui/DlgCalculateUrbanData.ui
+++ b/LDMP/gui/DlgCalculateUrbanData.ui
@@ -247,7 +247,7 @@
              <item>
               <widget class="QPushButton" name="region_button">
                <property name="toolTip">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Opens settings dialog in order to change region of interest.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Opens settings dialog in order to change region of interest.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                </property>
                <property name="text">
                 <string>Change region</string>
@@ -264,7 +264,11 @@
             </widget>
            </item>
            <item>
-            <widget class="QLineEdit" name="execution_name_le"/>
+            <widget class="QLineEdit" name="execution_name_le">
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Input for the name that will be assigned to the execution task, if not filled the algorithm name will be used as the task name.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+            </widget>
            </item>
            <item>
             <widget class="QLabel" name="task_notes_la">
@@ -292,6 +296,9 @@
                <width>16777215</width>
                <height>100</height>
               </size>
+             </property>
+             <property name="toolTip">
+              <string>User notes associated with the executed task.</string>
              </property>
             </widget>
            </item>

--- a/LDMP/gui/DlgCalculateUrbanSummaryTable.ui
+++ b/LDMP/gui/DlgCalculateUrbanSummaryTable.ui
@@ -160,7 +160,7 @@
              <item>
               <widget class="QPushButton" name="region_button">
                <property name="toolTip">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Opens settings dialog in order to change region of interest.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Opens settings dialog in order to change region of interest.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                </property>
                <property name="text">
                 <string>Change region</string>
@@ -177,7 +177,11 @@
             </widget>
            </item>
            <item>
-            <widget class="QLineEdit" name="execution_name_le"/>
+            <widget class="QLineEdit" name="execution_name_le">
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Input for the name that will be assigned to the execution task, if not filled the algorithm name will be used as the task name.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+            </widget>
            </item>
            <item>
             <widget class="QLabel" name="task_notes_la">
@@ -205,6 +209,9 @@
                <width>16777215</width>
                <height>100</height>
               </size>
+             </property>
+             <property name="toolTip">
+              <string>User notes associated with the executed task.</string>
              </property>
             </widget>
            </item>

--- a/LDMP/gui/land_cover_setup_widget.ui
+++ b/LDMP/gui/land_cover_setup_widget.ui
@@ -25,6 +25,9 @@
      </item>
      <item row="0" column="1">
       <widget class="QDateEdit" name="initial_year_de">
+       <property name="toolTip">
+        <string>Select the initial year, should be less than target year</string>
+       </property>
        <property name="displayFormat">
         <string>yyyy</string>
        </property>
@@ -46,6 +49,9 @@
      </item>
      <item row="1" column="1">
       <widget class="QDateEdit" name="target_year_de">
+       <property name="toolTip">
+        <string>Select the target year, should be great than initial year</string>
+       </property>
        <property name="displayFormat">
         <string>yyyy</string>
        </property>

--- a/LDMP/gui/land_cover_setup_widget_local.ui
+++ b/LDMP/gui/land_cover_setup_widget_local.ui
@@ -40,6 +40,9 @@
      </item>
      <item row="0" column="1">
       <widget class="WidgetDataIOSelectTELayerImport" name="initial_year_layer_cb">
+       <property name="toolTip">
+        <string>Select initial year from a dataset, make sure the year is not equal or great than the target year</string>
+       </property>
        <property name="layer_type" stdset="0">
         <string>Land cover (7 class)</string>
        </property>
@@ -59,6 +62,9 @@
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>Select target year from a dataset, make sure the year is not equal or less than the initial year</string>
        </property>
        <property name="layer_type" stdset="0">
         <string>Land cover (7 class)</string>

--- a/LDMP/jobs/mvc.py
+++ b/LDMP/jobs/mvc.py
@@ -99,8 +99,8 @@ class JobsSortFilterProxyModel(QtCore.QSortFilterProxyModel):
         jobs_model = self.sourceModel()
         index = jobs_model.index(source_row, 0, source_parent)
         job: models.Job = jobs_model.data(index)
-        match = self.filterRegularExpression().match(job.visible_name)
-        return match.hasMatch()
+        reg_exp = self.filterRegExp()
+        return reg_exp.exactMatch(job.visible_name)
 
     def lessThan(self, left: QtCore.QModelIndex, right: QtCore.QModelIndex) -> bool:
         model = self.sourceModel()

--- a/LDMP/main_widget.py
+++ b/LDMP/main_widget.py
@@ -178,6 +178,7 @@ class MainWidget(QtWidgets.QDockWidget, DockWidgetTrendsEarthUi):
         model = jobs_mvc.JobsModel(job_manager)
         # self.datasets_tv.setModel(model)
         self.proxy_model = jobs_mvc.JobsSortFilterProxyModel(SortField.DATE)
+        self.filter_changed("")
         self.proxy_model.setSourceModel(model)
         self.lineEdit_search.valueChanged.connect(self.filter_changed)
         self.datasets_tv.setModel(self.proxy_model)
@@ -286,10 +287,25 @@ class MainWidget(QtWidgets.QDockWidget, DockWidgetTrendsEarthUi):
         self.refresh_after_cache_update()
 
     def filter_changed(self, filter_string: str):
-        options = QtCore.QRegularExpression.NoPatternOption
-        options |= QtCore.QRegularExpression.CaseInsensitiveOption
-        regular_expression = QtCore.QRegularExpression(filter_string, options)
-        self.proxy_model.setFilterRegularExpression(regular_expression)
+        special_chars = [
+            "*",
+            ".",
+            "[",
+            "]",
+        ]
+        has_special_char = False
+        for char in filter_string:
+            if char in special_chars:
+                has_special_char = True
+                break
+        filter_ = filter_string if has_special_char else f"{filter_string}*"
+        self.proxy_model.setFilterRegExp(
+            QtCore.QRegExp(
+                filter_,
+                QtCore.Qt.CaseInsensitive,
+                QtCore.QRegExp.Wildcard
+            )
+        )
 
     def setup_algorithms_tree(self):
         self.algorithms_tv.setStyleSheet(


### PR DESCRIPTION
This PR replaces our usage of `QRegularExpression` with `QRegExp`. This allows supporting users that have a version of Qt < 5.12