### PR TITLE
drop existing style from the GPKG (fix #587)

### DIFF
--- a/LDMP/layers.py
+++ b/LDMP/layers.py
@@ -987,4 +987,8 @@ def set_default_value(v_path: str, field: str, r_path: str, band: int, v: int):
 
     idx = layer.fields().lookupField(field)
     layer.setDefaultValueDefinition(idx, QgsDefaultValue("calculate_charts('{}', {}, {})".format(r_path, band, v), True))
+    exists, msg = QgsProviderRegistry.instance().styleExists('ogr', layer.source(), 'false_positive')
+    if exists:
+        QgsProviderRegistry.instance().deleteStyleById('ogr', l.source(), '1', msg)
+
     layer.saveStyleToDatabase('false_positive', '', True, '')

--- a/LDMP/layers.py
+++ b/LDMP/layers.py
@@ -976,7 +976,6 @@ def add_vector_layer(layer_path: str, name: str, start_editing: bool):
 
 def set_default_value(v_path: str, field: str, r_path: str, band: int, v: int):
     sublayers = QgsProviderRegistry.instance().providerMetadata('ogr').querySublayers(v_path)
-
     layer = None
     if len(sublayers) > 0:
         options = QgsProviderSublayerDetails.LayerOptions(QgsProject.instance().transformContext())
@@ -984,11 +983,10 @@ def set_default_value(v_path: str, field: str, r_path: str, band: int, v: int):
         layer = sublayers[0].toLayer(options)
     else:
         layer = QgsVectorLayer(v_path, '', 'ogr')
-
     idx = layer.fields().lookupField(field)
     layer.setDefaultValueDefinition(idx, QgsDefaultValue("calculate_charts('{}', {}, {})".format(r_path, band, v), True))
-    exists, msg = QgsProviderRegistry.instance().styleExists('ogr', layer.source(), 'false_positive')
-    if exists:
-        QgsProviderRegistry.instance().deleteStyleById('ogr', l.source(), '1', msg)
-
+    res = layer.listStylesInDatabase()
+    if res[0] > 0:
+        for i in res[1]:
+            layer.deleteStyleFromDatabase(i)
     layer.saveStyleToDatabase('false_positive', '', True, '')


### PR DESCRIPTION
Old QGIS versions show popup when style saved under the same name, so we have to drop it before saving.