### PR TITLE
Fix loading DlgTimeseries.ui on Linux

### DIFF
--- a/LDMP/timeseries.py
+++ b/LDMP/timeseries.py
@@ -2,7 +2,7 @@
 """
 /***************************************************************************
  LDMP - A QGIS plugin
- This plugin supports monitoring and reporting of land degradation to the UNCCD 
+ This plugin supports monitoring and reporting of land degradation to the UNCCD
  and in support of the SDG Land Degradation Neutrality (LDN) target.
                               -------------------
         begin                : 2017-05-23
@@ -33,7 +33,7 @@ from .settings import AreaWidgetSection
 
 
 Ui_DlgTimeseries, _ = uic.loadUiType(
-    str(Path(__file__).parent / "gui/DlgTimeSeries.ui")
+    str(Path(__file__).parent / "gui/DlgTimeseries.ui")
 )
 
 


### PR DESCRIPTION
Hi,

Thanks for all your work on Trends.Earth! I've faced an error loading the plugin on Linux because it uses case-sensitive paths. Here is a fix.