### PR TITLE
Fix error in setting job extent

### DIFF
--- a/LDMP/jobs/manager.py
+++ b/LDMP/jobs/manager.py
@@ -154,6 +154,8 @@ def _set_results_extents_vector(job):
 
 
 def set_results_extents(job):
+    if not job.results:
+        return
     if job.results.type == results.ResultType.RASTER_RESULTS and job.status in [
         jobs.JobStatus.DOWNLOADED,
         jobs.JobStatus.GENERATED_LOCALLY,


### PR DESCRIPTION
Fix for https://github.com/ConservationInternational/trends.earth/issues/738
These changes ensure that jobs are only set with results extent when the results are avaialable, this  also prevents accessing `None` results which can lead to `AttributeError`.