### PR TITLE
Dev landcover matrix

### DIFF
--- a/LDMP/conf.py
+++ b/LDMP/conf.py
@@ -29,8 +29,10 @@ OPTIONS_ICON = "trends_earth_logo_square_32x32.ico"
 OPTIONS_TITLE = "Trends.Earth"
 
 # Degradation Landcover matrix size settings
-RESIZE_NUM_ROWS = 5  # If there are equal to less than this value rows than the row height will be decreased
-MINIMUM_ROW_HEIGHT = 40  # This is the minimum row height value. 40 is the minimum at the moment, based on the font
+# If there are equal to less than this value rows than the row height will be decreased
+RESIZE_NUM_ROWS = 5
+# This is the minimum row height value. 40 is the cell font minimum
+MINIMUM_ROW_HEIGHT = 40
 
 class AreaSetting(enum.Enum):
     COUNTRY_REGION = "country_region"

--- a/LDMP/conf.py
+++ b/LDMP/conf.py
@@ -34,6 +34,7 @@ RESIZE_NUM_ROWS = 5
 # This is the minimum row height value. 40 is the cell font minimum
 MINIMUM_ROW_HEIGHT = 40
 
+
 class AreaSetting(enum.Enum):
     COUNTRY_REGION = "country_region"
     COUNTRY_CITY = "country_city"

--- a/LDMP/conf.py
+++ b/LDMP/conf.py
@@ -28,6 +28,9 @@ TR_ALL_REGIONS = tr_conf.tr("All regions")
 OPTIONS_ICON = "trends_earth_logo_square_32x32.ico"
 OPTIONS_TITLE = "Trends.Earth"
 
+# Degradation Landcover matrix size settings
+RESIZE_NUM_ROWS = 5  # If there are equal to less than this value rows than the row height will be decreased
+MINIMUM_ROW_HEIGHT = 40  # This is the minimum row height value. 40 is the minimum at the moment, based on the font
 
 class AreaSetting(enum.Enum):
     COUNTRY_REGION = "country_region"

--- a/LDMP/lc_setup.py
+++ b/LDMP/lc_setup.py
@@ -1204,6 +1204,16 @@ class LCDefineDegradationWidget(QtWidgets.QWidget, WidgetLcDefineDegradationUi):
             "QLineEdit {background: #FFFFE0;} QLineEdit:hover {border: 1px solid gray; background: #FFFFE0;}"
         )
 
+        table_header = self.deg_def_matrix.horizontalHeader()
+        header_height = table_header.height()
+
+        table_row_cnt = self.deg_def_matrix.rowCount()
+        table_row_height = self.deg_def_matrix.rowHeight(0)
+        # Table height with 10 added as an additional precaution to avoid the addition of a scroll bar
+        table_height = (table_row_height * table_row_cnt) + header_height + 10
+
+        self.deg_def_matrix.setFixedHeight(table_height)
+
     def setup_deg_def_matrix(self, legend):
         self.deg_def_matrix.setRowCount(len(legend.key))
         self.deg_def_matrix.setColumnCount(len(legend.key))

--- a/LDMP/lc_setup.py
+++ b/LDMP/lc_setup.py
@@ -1262,8 +1262,7 @@ class LCDefineDegradationWidget(QtWidgets.QWidget, WidgetLcDefineDegradationUi):
                     col, QtWidgets.QHeaderView.Fixed
                 )
                 self.deg_def_matrix.verticalHeader().resizeSection(
-                    col,
-                    conf.MINIMUM_ROW_HEIGHT
+                    col, conf.MINIMUM_ROW_HEIGHT
                 )
             else:
                 # Automatic resizing works perfect when there are a large number of rows

--- a/LDMP/lc_setup.py
+++ b/LDMP/lc_setup.py
@@ -1204,7 +1204,7 @@ class LCDefineDegradationWidget(QtWidgets.QWidget, WidgetLcDefineDegradationUi):
             "QLineEdit {background: #FFFFE0;} QLineEdit:hover {border: 1px solid gray; background: #FFFFE0;}"
         )
 
-        # Sets the LC table size based on the row height
+        # Sets the LC table height based on the row height
         table_header = self.deg_def_matrix.horizontalHeader()
         header_height = table_header.height()
 
@@ -1215,6 +1215,18 @@ class LCDefineDegradationWidget(QtWidgets.QWidget, WidgetLcDefineDegradationUi):
         # avoid the addition of a scroll bar
         table_height = (table_row_height * table_row_cnt) + header_height + 5
         self.deg_def_matrix.setFixedHeight(table_height)
+
+        # Sets the LC table width based on the column width
+        table_vheader = self.deg_def_matrix.verticalHeader()
+        header_width = table_vheader.width()
+
+        table_column_cnt = self.deg_def_matrix.columnCount()
+        # There will always be atleast one class
+        table_column_width = self.deg_def_matrix.columnWidth(0)
+        # Table height with 5 added as an additional precaution to
+        # avoid the addition of a scroll bar
+        table_width = (table_column_width * table_column_cnt) + header_width + 5
+        self.deg_def_matrix.setFixedWidth(table_width)
 
     def setup_deg_def_matrix(self, legend):
         self.deg_def_matrix.setRowCount(len(legend.key))

--- a/LDMP/lc_setup.py
+++ b/LDMP/lc_setup.py
@@ -1209,8 +1209,10 @@ class LCDefineDegradationWidget(QtWidgets.QWidget, WidgetLcDefineDegradationUi):
         header_height = table_header.height()
 
         table_row_cnt = self.deg_def_matrix.rowCount()
-        table_row_height = self.deg_def_matrix.rowHeight(0)  # There will always be atleast one class
-        # Table height with 5 added as an additional precaution to avoid the addition of a scroll bar
+        # There will always be atleast one class
+        table_row_height = self.deg_def_matrix.rowHeight(0)
+        # Table height with 5 added as an additional precaution to
+        # avoid the addition of a scroll bar
         table_height = (table_row_height * table_row_cnt) + header_height + 5
         self.deg_def_matrix.setFixedHeight(table_height)
 
@@ -1259,7 +1261,10 @@ class LCDefineDegradationWidget(QtWidgets.QWidget, WidgetLcDefineDegradationUi):
                 self.deg_def_matrix.verticalHeader().setSectionResizeMode(
                     col, QtWidgets.QHeaderView.Fixed
                 )
-                self.deg_def_matrix.verticalHeader().resizeSection(col, conf.MINIMUM_ROW_HEIGHT)
+                self.deg_def_matrix.verticalHeader().resizeSection(
+                    col,
+                    conf.MINIMUM_ROW_HEIGHT
+                )
             else:
                 # Automatic resizing works perfect when there are a large number of rows
                 self.deg_def_matrix.verticalHeader().setSectionResizeMode(

--- a/LDMP/lc_setup.py
+++ b/LDMP/lc_setup.py
@@ -1204,14 +1204,14 @@ class LCDefineDegradationWidget(QtWidgets.QWidget, WidgetLcDefineDegradationUi):
             "QLineEdit {background: #FFFFE0;} QLineEdit:hover {border: 1px solid gray; background: #FFFFE0;}"
         )
 
+        # Sets the LC table size based on the row height
         table_header = self.deg_def_matrix.horizontalHeader()
         header_height = table_header.height()
 
         table_row_cnt = self.deg_def_matrix.rowCount()
-        table_row_height = self.deg_def_matrix.rowHeight(0)
-        # Table height with 10 added as an additional precaution to avoid the addition of a scroll bar
-        table_height = (table_row_height * table_row_cnt) + header_height + 10
-
+        table_row_height = self.deg_def_matrix.rowHeight(0)  # There will always be atleast one class
+        # Table height with 5 added as an additional precaution to avoid the addition of a scroll bar
+        table_height = (table_row_height * table_row_cnt) + header_height + 5
         self.deg_def_matrix.setFixedHeight(table_height)
 
     def setup_deg_def_matrix(self, legend):
@@ -1252,10 +1252,19 @@ class LCDefineDegradationWidget(QtWidgets.QWidget, WidgetLcDefineDegradationUi):
                 row, QtWidgets.QHeaderView.Stretch
             )
 
-        for col in range(0, self.deg_def_matrix.columnCount()):
-            self.deg_def_matrix.verticalHeader().setSectionResizeMode(
-                col, QtWidgets.QHeaderView.Stretch
-            )
+        num_of_col = self.deg_def_matrix.columnCount()
+        for col in range(0, num_of_col):
+            if num_of_col <= conf.RESIZE_NUM_ROWS:
+                # When there are only a few rows, it's better to use the minimum size
+                self.deg_def_matrix.verticalHeader().setSectionResizeMode(
+                    col, QtWidgets.QHeaderView.Fixed
+                )
+                self.deg_def_matrix.verticalHeader().resizeSection(col, conf.MINIMUM_ROW_HEIGHT)
+            else:
+                # Automatic resizing works perfect when there are a large number of rows
+                self.deg_def_matrix.verticalHeader().setSectionResizeMode(
+                    col, QtWidgets.QHeaderView.Stretch
+                )
 
     def trans_matrix_loadfile(self):
         f, _ = QtWidgets.QFileDialog.getOpenFileName(

--- a/LDMP/lc_setup.py
+++ b/LDMP/lc_setup.py
@@ -1251,6 +1251,10 @@ class LCDefineDegradationWidget(QtWidgets.QWidget, WidgetLcDefineDegradationUi):
                 line_edit = TransMatrixEdit()
                 line_edit.setValidator(QtGui.QRegExpValidator(QtCore.QRegExp("[-0+]")))
                 line_edit.setAlignment(QtCore.Qt.AlignHCenter)
+                line_edit.setToolTip(
+                    f"Initial: {legend.key[row].get_name_long()}, "
+                    f"<br>Final: {legend.key[col].get_name_long()}"
+                )
                 self.deg_def_matrix.setCellWidget(row, col, line_edit)
 
         self.deg_def_matrix.setStyleSheet("QTableWidget {border: 0px;}")


### PR DESCRIPTION
fixes #725 

The degradation landcover table will now increase in size as the number of rows increases - this will avoid an additional scroll bar for the table:
![image](https://user-images.githubusercontent.com/79740955/206436665-4f6be9a0-2b94-42d6-9d96-cf94eb8fd07c.png)

If there are 5 or less rows in the table, the row height will be set to 40. The value 40 is used because its the lowest value that can be used, due to the minimum value based on the font used for the table cells.
![image](https://user-images.githubusercontent.com/79740955/206437025-b6a4548b-dd02-4b9c-9e0f-bab937035705.png)
