### PR TITLE
Offline mode support

### DIFF
--- a/LDMP/algorithms/mvc.py
+++ b/LDMP/algorithms/mvc.py
@@ -7,9 +7,10 @@ from qgis.PyQt import QtGui
 from qgis.PyQt import QtWidgets
 from qgis.PyQt import uic
 from te_schemas.algorithms import AlgorithmRunMode
-from ..conf import settings_manager, Setting
 
 from . import models
+from ..conf import Setting
+from ..conf import settings_manager
 
 WidgetAlgorithmLeafUi, _ = uic.loadUiType(
     str(Path(__file__).parents[1] / "gui/WidgetAlgorithmLeaf.ui")

--- a/LDMP/conf.py
+++ b/LDMP/conf.py
@@ -34,8 +34,8 @@ RESIZE_NUM_ROWS = 5
 # This is the minimum row height value. 40 is the cell font minimum
 MINIMUM_ROW_HEIGHT = 40
 
-DOCK_TITLE = 'Trends.Earth'
-DOCK_TITLE_OFFLINE = 'Trends.Earth (offline mode)'
+DOCK_TITLE = "Trends.Earth"
+DOCK_TITLE_OFFLINE = "Trends.Earth (offline mode)"
 
 
 class AreaSetting(enum.Enum):

--- a/LDMP/conf.py
+++ b/LDMP/conf.py
@@ -34,6 +34,9 @@ RESIZE_NUM_ROWS = 5
 # This is the minimum row height value. 40 is the cell font minimum
 MINIMUM_ROW_HEIGHT = 40
 
+DOCK_TITLE = 'Trends.Earth'
+DOCK_TITLE_OFFLINE = 'Trends.Earth (offline mode)'
+
 
 class AreaSetting(enum.Enum):
     COUNTRY_REGION = "country_region"
@@ -58,6 +61,7 @@ class Setting(enum.Enum):
     POLL_REMOTE = "advanced/poll_remote_server"
     REMOTE_POLLING_FREQUENCY = "advanced/remote_polling_frequency_seconds"
     DOWNLOAD_RESULTS = "advanced/download_remote_results_automatically"
+    OFFLINE_MODE = 'advanced/offline_mode'
     BUFFER_CHECKED = "region_of_interest/buffer_checked"
     AREA_FROM_OPTION = "region_of_interest/chosen_method"
     POINT_X = "region_of_interest/point/x"
@@ -98,6 +102,7 @@ class SettingsManager:
         Setting.REMOTE_POLLING_FREQUENCY: 3 * 60,
         Setting.DEBUG: False,
         Setting.FILTER_JOBS_BY_BASE_DIR: True,
+        Setting.OFFLINE_MODE: False,
         Setting.BINARIES_ENABLED: False,
         Setting.BINARIES_DIR: str(Path.home()),
         Setting.BASE_DIR: str(Path.home() / _base_data_path),

--- a/LDMP/conf.py
+++ b/LDMP/conf.py
@@ -36,9 +36,6 @@ MINIMUM_ROW_HEIGHT = 40
 
 DOCK_TITLE = 'Trends.Earth'
 DOCK_TITLE_OFFLINE = 'Trends.Earth (offline mode)'
-=======
-DOCK_TITLE = "Trends.Earth"
-DOCK_TITLE_OFFLINE = "Trends.Earth (offline mode)"
 
 
 class AreaSetting(enum.Enum):

--- a/LDMP/conf.py
+++ b/LDMP/conf.py
@@ -36,6 +36,9 @@ MINIMUM_ROW_HEIGHT = 40
 
 DOCK_TITLE = 'Trends.Earth'
 DOCK_TITLE_OFFLINE = 'Trends.Earth (offline mode)'
+=======
+DOCK_TITLE = "Trends.Earth"
+DOCK_TITLE_OFFLINE = "Trends.Earth (offline mode)"
 
 
 class AreaSetting(enum.Enum):

--- a/LDMP/conf.py
+++ b/LDMP/conf.py
@@ -61,7 +61,7 @@ class Setting(enum.Enum):
     POLL_REMOTE = "advanced/poll_remote_server"
     REMOTE_POLLING_FREQUENCY = "advanced/remote_polling_frequency_seconds"
     DOWNLOAD_RESULTS = "advanced/download_remote_results_automatically"
-    OFFLINE_MODE = 'advanced/offline_mode'
+    OFFLINE_MODE = "advanced/offline_mode"
     BUFFER_CHECKED = "region_of_interest/buffer_checked"
     AREA_FROM_OPTION = "region_of_interest/chosen_method"
     POINT_X = "region_of_interest/point/x"

--- a/LDMP/gui/WidgetSettingsAdvanced.ui
+++ b/LDMP/gui/WidgetSettingsAdvanced.ui
@@ -99,6 +99,13 @@
     </widget>
    </item>
    <item>
+    <widget class="QCheckBox" name="cb_offline_mode">
+     <property name="text">
+      <string>Offline mode (all remote functionality will be disabled)</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QCheckBox" name="download_remote_datasets_chb">
      <property name="text">
       <string>Download remotely-generated datasets automatically</string>

--- a/LDMP/jobs/mvc.py
+++ b/LDMP/jobs/mvc.py
@@ -334,6 +334,7 @@ class DatasetEditorWidget(QtWidgets.QWidget, WidgetDatasetItemUi):
 
         self.delete_tb.setEnabled(True)
 
+        offline_mode = settings_manager.get_value(Setting.OFFLINE_MODE)
         # set visibility of progress bar and download button
         if self.job.is_vector():
             self.download_tb.hide()
@@ -374,7 +375,13 @@ class DatasetEditorWidget(QtWidgets.QWidget, WidgetDatasetItemUi):
                     self.download_tb.hide()
                 else:
                     self.download_tb.show()
-                    self.download_tb.setEnabled(True)
+
+                    if offline_mode:
+                        # Disable the download button so that the user cannot download
+                        self.download_tb.setEnabled(False)
+                    else:
+                        self.download_tb.setEnabled(True)
+
                     self.download_tb.clicked.connect(
                         functools.partial(manager.job_manager.download_job_results, job)
                     )

--- a/LDMP/main_widget.py
+++ b/LDMP/main_widget.py
@@ -16,11 +16,11 @@ from te_schemas.jobs import JobStatus
 from .algorithms import models as algorithm_models
 from .algorithms import mvc as algorithms_mvc
 from .conf import ALGORITHM_TREE
+from .conf import DOCK_TITLE
+from .conf import DOCK_TITLE_OFFLINE
 from .conf import KNOWN_SCRIPTS
 from .conf import Setting
 from .conf import settings_manager
-from .conf import DOCK_TITLE
-from .conf import DOCK_TITLE_OFFLINE
 from .data_io import DlgDataIOImportProd
 from .data_io import DlgDataIOImportSOC
 from .data_io import DlgDataIOLoadTE

--- a/LDMP/main_widget.py
+++ b/LDMP/main_widget.py
@@ -19,6 +19,8 @@ from .conf import ALGORITHM_TREE
 from .conf import KNOWN_SCRIPTS
 from .conf import Setting
 from .conf import settings_manager
+from .conf import DOCK_TITLE
+from .conf import DOCK_TITLE_OFFLINE
 from .data_io import DlgDataIOImportProd
 from .data_io import DlgDataIOImportSOC
 from .data_io import DlgDataIOLoadTE
@@ -156,6 +158,14 @@ class MainWidget(QtWidgets.QDockWidget, DockWidgetTrendsEarthUi):
             settings_manager.get_value(Setting.UPDATE_FREQUENCY_MILLISECONDS)
         )
 
+        offline_mode = settings_manager.get_value(Setting.OFFLINE_MODE)
+        if offline_mode:
+            self.pushButton_download.setEnabled(False)
+            self.setWindowTitle(DOCK_TITLE_OFFLINE)
+        else:
+            self.pushButton_download.setEnabled(True)
+            self.setWindowTitle(DOCK_TITLE)
+
     def setup_datasets_page_gui(self):
         self.pushButton_refresh.setIcon(
             QtGui.QIcon(os.path.join(ICON_PATH, "mActionRefresh.svg"))
@@ -258,6 +268,14 @@ class MainWidget(QtWidgets.QDockWidget, DockWidgetTrendsEarthUi):
         self.datasets_tv.setEditTriggers(QtWidgets.QAbstractItemView.AllEditTriggers)
         # self.datasets_tv.clicked.connect(self._manage_datasets_tree_view)
         self.datasets_tv.entered.connect(self._manage_datasets_tree_view)
+
+        offline_mode = settings_manager.get_value(Setting.OFFLINE_MODE)
+        if offline_mode:
+            self.pushButton_download.setEnabled(False)
+            self.setWindowTitle(DOCK_TITLE)
+        else:
+            self.pushButton_download.setEnabled(True)
+            self.setWindowTitle(DOCK_TITLE_OFFLINE)
 
     def refresh_after_cache_update(self):
         current_dataset_index = self.datasets_tv_delegate.current_index

--- a/LDMP/plugin.py
+++ b/LDMP/plugin.py
@@ -316,6 +316,9 @@ class LDMPPlugin:
                 self.dock_widget.visibilityChanged.connect(
                     self.on_dock_visibility_changed
                 )
+
+                self.options_factory.set_dock_widget(self.dock_widget)
+
             self.dock_widget.show()
         else:
             if self.dock_widget is not None and self.dock_widget.isVisible():

--- a/LDMP/settings.py
+++ b/LDMP/settings.py
@@ -232,7 +232,6 @@ class TrendsEarthSettings(Ui_DlgSettings, QgsOptionsPageWidget):
             self.dock_widget.pushButton_download.setEnabled(True)
             self.dock_widget.setWindowTitle(DOCK_TITLE)
 
-
     def closeEvent(self, event):
         self.widgetSettingsAdvanced.closeEvent(event)
         self.area_widget.closeEvent(event)
@@ -1079,7 +1078,7 @@ class WidgetSettingsAdvanced(QtWidgets.QWidget, Ui_WidgetSettingsAdvanced):
     message_bar: qgis.gui.QgsMessageBar
 
     def __init__(
-            self, group_box, dock_widget, message_bar: qgis.gui.QgsMessageBar, parent=None
+        self, group_box, dock_widget, message_bar: qgis.gui.QgsMessageBar, parent=None
     ):
         super().__init__(parent)
         self.setupUi(self)

--- a/LDMP/settings.py
+++ b/LDMP/settings.py
@@ -37,13 +37,13 @@ from . import binaries_name
 from . import conf
 from . import download
 from . import openFolder
+from .conf import DOCK_TITLE
+from .conf import DOCK_TITLE_OFFLINE
 from .conf import OPTIONS_ICON
 from .conf import OPTIONS_TITLE
 from .conf import Setting
 from .conf import settings_manager
 from .conf import TR_ALL_REGIONS
-from .conf import DOCK_TITLE
-from .conf import DOCK_TITLE_OFFLINE
 from .jobs.manager import job_manager
 from .lc_setup import get_default_esa_nesting
 from .lc_setup import LccInfoUtils

--- a/LDMP/settings.py
+++ b/LDMP/settings.py
@@ -42,6 +42,8 @@ from .conf import OPTIONS_TITLE
 from .conf import Setting
 from .conf import settings_manager
 from .conf import TR_ALL_REGIONS
+from .conf import DOCK_TITLE
+from .conf import DOCK_TITLE_OFFLINE
 from .jobs.manager import job_manager
 from .lc_setup import get_default_esa_nesting
 from .lc_setup import LccInfoUtils
@@ -138,15 +140,18 @@ def _get_user_email(auth_setup, warn=True):
 class TrendsEarthSettings(Ui_DlgSettings, QgsOptionsPageWidget):
     message_bar: qgis.gui.QgsMessageBar
 
-    def __init__(self, parent=None):
+    def __init__(self, dock_widget, parent=None):
         QgsOptionsPageWidget.__init__(self, parent)
 
         self.setupUi(self)
         self.message_bar = qgis.gui.QgsMessageBar(self)
         self.layout().insertWidget(0, self.message_bar)
+        self.dock_widget = dock_widget
 
         # Add subcomponent widgets
         self.widgetSettingsAdvanced = WidgetSettingsAdvanced(
+            self.groupBox,
+            self.dock_widget,
             message_bar=self.message_bar
         )
         self.verticalLayout_advanced.layout().insertWidget(
@@ -220,6 +225,15 @@ class TrendsEarthSettings(Ui_DlgSettings, QgsOptionsPageWidget):
             job_manager.clear_known_jobs()
             if hasattr(self, "dock_widget") and self.dock_widget.isVisible():
                 self.dock_widget.refresh_after_cache_update()
+
+        offline_mode = settings_manager.get_value(Setting.OFFLINE_MODE)
+        if offline_mode:
+            self.dock_widget.pushButton_download.setEnabled(False)
+            self.dock_widget.setWindowTitle(DOCK_TITLE_OFFLINE)
+        else:
+            self.dock_widget.pushButton_download.setEnabled(True)
+            self.dock_widget.setWindowTitle(DOCK_TITLE)
+
 
     def closeEvent(self, event):
         self.widgetSettingsAdvanced.closeEvent(event)
@@ -1066,10 +1080,18 @@ class WidgetSettingsAdvanced(QtWidgets.QWidget, Ui_WidgetSettingsAdvanced):
 
     message_bar: qgis.gui.QgsMessageBar
 
-    def __init__(self, message_bar: qgis.gui.QgsMessageBar, parent=None):
+    def __init__(
+            self,
+            group_box,
+            dock_widget,
+            message_bar: qgis.gui.QgsMessageBar,
+            parent=None
+    ):
         super().__init__(parent)
         self.setupUi(self)
 
+        self.group_box = group_box
+        self.dock_widget = dock_widget
         self.message_bar = message_bar
 
         self.dlg_settings_login_landpks = DlgSettingsLoginLandPKS()
@@ -1082,6 +1104,7 @@ class WidgetSettingsAdvanced(QtWidgets.QWidget, Ui_WidgetSettingsAdvanced):
             self.base_directory_changed
         )
         self.pushButton_open_base_directory.clicked.connect(self.open_base_directory)
+        self.cb_offline_mode.stateChanged.connect(self.set_offline_mode_states)
 
         # Flag that can be used to indicate if binary state has changed (i.e.
         # if new binaries have been downloaded)
@@ -1125,6 +1148,7 @@ class WidgetSettingsAdvanced(QtWidgets.QWidget, Ui_WidgetSettingsAdvanced):
             Setting.BINARIES_ENABLED, self.binaries_gb.isChecked()
         )
         settings_manager.write_value(Setting.BINARIES_DIR, self.binaries_dir_le.text())
+        settings_manager.write_value(Setting.OFFLINE_MODE, self.cb_offline_mode.isChecked())
 
         old_base_dir = settings_manager.get_value(Setting.BASE_DIR)
         new_base_dir = self.qgsFileWidget_base_directory.filePath()
@@ -1138,6 +1162,9 @@ class WidgetSettingsAdvanced(QtWidgets.QWidget, Ui_WidgetSettingsAdvanced):
 
     def show_settings(self):
         self.debug_checkbox.setChecked(settings_manager.get_value(Setting.DEBUG))
+        self.cb_offline_mode.setChecked(
+            settings_manager.get_value(Setting.OFFLINE_MODE)
+        )
         self.filter_jobs_by_basedir_checkbox.setChecked(
             settings_manager.get_value(Setting.FILTER_JOBS_BY_BASE_DIR)
         )
@@ -1157,9 +1184,46 @@ class WidgetSettingsAdvanced(QtWidgets.QWidget, Ui_WidgetSettingsAdvanced):
             settings_manager.get_value(Setting.DOWNLOAD_RESULTS)
         )
 
+    def set_offline_mode_states(self):
+        """ This funtion is called when offline mode is enabled or disabled.
+        If offline mode is enabled, then all settings related to online
+        requests (e.g. download remote datasets or polling the server) will
+        be disabled as well. The login section will also be disabled.
+        If offline mode is disabled, all of the above features will be
+        reenabled.
+        """
+
+        if self.cb_offline_mode.isChecked():
+            # Offline mode is enabled
+            self.download_remote_datasets_chb.setEnabled(False)
+            self.download_remote_datasets_chb.setChecked(False)
+
+            # Polling frequency settings
+            self.polling_frequency_gb.setEnabled(False)
+            self.polling_frequency_gb.setChecked(False)
+
+            # Login settings
+            self.group_box.setEnabled(False)
+
+            self.message_bar.pushWarning(
+                "Trends.Earth", self.tr("Offline mode is enabled.")
+            )
+        else:
+            # Offline mode is disabled
+            self.download_remote_datasets_chb.setEnabled(True)
+            self.download_remote_datasets_chb.setChecked(True)
+
+            # Polling frequency settings
+            self.polling_frequency_gb.setEnabled(True)
+            self.polling_frequency_gb.setChecked(True)
+
+            # Login settings
+            self.group_box.setEnabled(True)
+
     def showEvent(self, event):
         super().showEvent(event)
         self.show_settings()
+        self.set_offline_mode_states()
         binaries_checked = settings_manager.get_value(Setting.BINARIES_ENABLED)
         # TODO: Have this actually check if they are enabled in summary_numba
         # and calculate_numba. Right now this doesn't really check if they are
@@ -2292,6 +2356,8 @@ class LandCoverCustomClassEditor(
 class TrendsEarthOptionsFactory(QgsOptionsWidgetFactory):
     def __init__(self):  # pylint: disable=useless-super-delegation
         super().__init__()
+
+        self.dock_widget = None
         self.setTitle(OPTIONS_TITLE)
 
     def icon(self):  # pylint: disable=missing-function-docstring
@@ -2299,5 +2365,10 @@ class TrendsEarthOptionsFactory(QgsOptionsWidgetFactory):
 
         return QIcon(trends_earth_icon)
 
+    def set_dock_widget(self, dock_widget):
+        # Widget required to update the title for the dock based
+        # on the offline mode state
+        self.dock_widget = dock_widget
+
     def createWidget(self, parent):  # pylint: disable=missing-function-docstring
-        return TrendsEarthSettings(parent)
+        return TrendsEarthSettings(self.dock_widget, parent)

--- a/LDMP/settings.py
+++ b/LDMP/settings.py
@@ -150,9 +150,7 @@ class TrendsEarthSettings(Ui_DlgSettings, QgsOptionsPageWidget):
 
         # Add subcomponent widgets
         self.widgetSettingsAdvanced = WidgetSettingsAdvanced(
-            self.groupBox,
-            self.dock_widget,
-            message_bar=self.message_bar
+            self.groupBox, self.dock_widget, message_bar=self.message_bar
         )
         self.verticalLayout_advanced.layout().insertWidget(
             0, self.widgetSettingsAdvanced
@@ -1081,11 +1079,7 @@ class WidgetSettingsAdvanced(QtWidgets.QWidget, Ui_WidgetSettingsAdvanced):
     message_bar: qgis.gui.QgsMessageBar
 
     def __init__(
-            self,
-            group_box,
-            dock_widget,
-            message_bar: qgis.gui.QgsMessageBar,
-            parent=None
+            self, group_box, dock_widget, message_bar: qgis.gui.QgsMessageBar, parent=None
     ):
         super().__init__(parent)
         self.setupUi(self)
@@ -1148,7 +1142,9 @@ class WidgetSettingsAdvanced(QtWidgets.QWidget, Ui_WidgetSettingsAdvanced):
             Setting.BINARIES_ENABLED, self.binaries_gb.isChecked()
         )
         settings_manager.write_value(Setting.BINARIES_DIR, self.binaries_dir_le.text())
-        settings_manager.write_value(Setting.OFFLINE_MODE, self.cb_offline_mode.isChecked())
+        settings_manager.write_value(
+            Setting.OFFLINE_MODE, self.cb_offline_mode.isChecked()
+        )
 
         old_base_dir = settings_manager.get_value(Setting.BASE_DIR)
         new_base_dir = self.qgsFileWidget_base_directory.filePath()
@@ -1185,7 +1181,7 @@ class WidgetSettingsAdvanced(QtWidgets.QWidget, Ui_WidgetSettingsAdvanced):
         )
 
     def set_offline_mode_states(self):
-        """ This funtion is called when offline mode is enabled or disabled.
+        """This funtion is called when offline mode is enabled or disabled.
         If offline mode is enabled, then all settings related to online
         requests (e.g. download remote datasets or polling the server) will
         be disabled as well. The login section will also be disabled.


### PR DESCRIPTION
fixes #697 

Adds offline mode support to the plugin. The user can enable the offline mode by going to the Trends.Earth options, in the Advanced section.
![image](https://user-images.githubusercontent.com/79740955/207078702-021f72bf-cd24-48d4-9afd-b2729d8e36ef.png)

Login info disabled
![image](https://user-images.githubusercontent.com/79740955/207078741-bf86b2f0-28e7-4312-a4ba-5e9114358589.png)

Remote algorithms are disabled:
![image](https://user-images.githubusercontent.com/79740955/207078762-2764146a-b2e8-4094-bf77-14bfa2fe2011.png)

- The dock title will change to "Trends.Earth (offline mode)".
- Periodic calls to the server (e.g. refresh data list) is disabled.
- Download dataset button disabled
- Remote processes will no longer be displayed in the list. Disabling offline mode and clicking refresh will show them again