### PR TITLE
Changing Dataset CRS

### DIFF
--- a/LDMP/calculate.py
+++ b/LDMP/calculate.py
@@ -531,7 +531,7 @@ class DlgCalculateBase(QtWidgets.QDialog):
             currentPage=OPTIONS_TITLE
         )
 
-    def _validate_crs(self, layer_defn: list) -> bool:
+    def _validate_crs_multi_layer(self, layer_defn: list) -> bool:
         """
         Compares the CRS of the layer(s) in the given definition against
         the one defined for datasets in settings.

--- a/LDMP/calculate_drought_vulnerability.py
+++ b/LDMP/calculate_drought_vulnerability.py
@@ -284,7 +284,7 @@ class DlgCalculateDroughtSummary(DlgCalculateBase, DlgCalculateDroughtSummaryUi)
             )
         ]
 
-        if not self._validate_crs(crs_check_defn):
+        if not self._validate_crs_multi_layer(crs_check_defn):
             return
 
         log("passed all validation checks")

--- a/LDMP/calculate_drought_vulnerability.py
+++ b/LDMP/calculate_drought_vulnerability.py
@@ -271,8 +271,23 @@ class DlgCalculateDroughtSummary(DlgCalculateBase, DlgCalculateDroughtSummaryUi)
             log("failed layer validation")
 
             return
-        else:
-            log("passed all validation checks")
+
+        # Check layers' CRS
+        crs_check_defn = [
+            (
+                self.combo_dataset_drought.get_current_layer(),
+                self.tr("drought (hazard and exposure) layer")
+            ),
+            (
+                self.combo_layer_so3_vulnerability.get_layer(),
+                self.tr("drought (vulnerability) layer")
+            )
+        ]
+
+        if not self._validate_crs(crs_check_defn):
+            return
+
+        log("passed all validation checks")
 
         params = {
             "task_name": self.options_tab.task_name.text(),

--- a/LDMP/calculate_lc.py
+++ b/LDMP/calculate_lc.py
@@ -200,7 +200,7 @@ class DlgCalculateLC(calculate.DlgCalculateBase, DlgCalculateLcUi):
             (final_layer, self.tr("target layer"))
         ]
 
-        if not self._validate_crs(crs_check_defn):
+        if not self._validate_crs_multi_layer(crs_check_defn):
             return
 
         self.close()

--- a/LDMP/calculate_lc.py
+++ b/LDMP/calculate_lc.py
@@ -194,6 +194,15 @@ class DlgCalculateLC(calculate.DlgCalculateBase, DlgCalculateLcUi):
             )
             return
 
+        # Check layers' CRS
+        crs_check_defn = [
+            (initial_layer, self.tr("initial layer")),
+            (final_layer, self.tr("target layer"))
+        ]
+
+        if not self._validate_crs(crs_check_defn):
+            return
+
         self.close()
 
         trans_matrix = self.lc_define_deg_widget.get_trans_matrix_from_widget()

--- a/LDMP/calculate_ldn.py
+++ b/LDMP/calculate_ldn.py
@@ -899,8 +899,17 @@ class DlgCalculateLDNSummaryTableAdmin(
                 ),
             )
             return False
-        else:
-            return True
+
+        # Include check for CRS defined in settings
+        crs_check_defn = [
+            (model_layer, model_layer_name),
+            (check_layer, check_layer_name)
+        ]
+
+        if not self._validate_crs(crs_check_defn):
+            return False
+
+        return True
 
     def validate_layer_crs(self, combo_boxes, pop_mode):
         """check all layers have the same resolution and CRS"""

--- a/LDMP/calculate_ldn.py
+++ b/LDMP/calculate_ldn.py
@@ -906,7 +906,7 @@ class DlgCalculateLDNSummaryTableAdmin(
             (check_layer, check_layer_name)
         ]
 
-        if not self._validate_crs(crs_check_defn):
+        if not self._validate_crs_multi_layer(crs_check_defn):
             return False
 
         return True

--- a/LDMP/calculate_soc.py
+++ b/LDMP/calculate_soc.py
@@ -25,6 +25,7 @@ from te_schemas.land_cover import LCTransitionDefinitionDeg
 from . import calculate
 from . import data_io
 from . import lc_setup
+from .conf import settings_crs
 from .jobs.manager import job_manager
 from .lc_setup import get_trans_matrix
 from .logger import log
@@ -191,7 +192,7 @@ class DlgCalculateSOC(calculate.DlgCalculateBase, DlgCalculateSocUi):
                 self.tr("Warning"),
                 self.tr(
                     f"The initial year ({year_initial}) is greater than or "
-                    "equal to the final year ({year_final}) - this analysis "
+                    f"equal to the final year ({year_final}) - this analysis "
                     "might generate strange results."
                 ),
             )
@@ -222,6 +223,15 @@ class DlgCalculateSOC(calculate.DlgCalculateBase, DlgCalculateSocUi):
                     "layer."
                 ),
             )
+            return
+
+        # Check layers' CRS
+        crs_check_defn = [
+            (initial_layer, self.tr("initial layer")),
+            (final_layer, self.tr("target layer"))
+        ]
+
+        if not self._validate_crs(crs_check_defn):
             return
 
         self.close()

--- a/LDMP/calculate_soc.py
+++ b/LDMP/calculate_soc.py
@@ -231,7 +231,7 @@ class DlgCalculateSOC(calculate.DlgCalculateBase, DlgCalculateSocUi):
             (final_layer, self.tr("target layer"))
         ]
 
-        if not self._validate_crs(crs_check_defn):
+        if not self._validate_crs_multi_layer(crs_check_defn):
             return
 
         self.close()

--- a/LDMP/conf.py
+++ b/LDMP/conf.py
@@ -87,6 +87,7 @@ class Setting(enum.Enum):
     LC_LAST_DIR = "land_cover/last_dir"
     LC_IPCC_NESTING = "land_cover/ipcc_nesting"
     LC_ESA_NESTING = "land_cover/esa_nesting"
+    DEFAULT_CRS = "crs/default"
 
 
 class SettingsManager:
@@ -137,6 +138,7 @@ class SettingsManager:
         Setting.LC_LAST_DIR: "",
         Setting.LC_IPCC_NESTING: "",
         Setting.LC_ESA_NESTING: "",
+        Setting.DEFAULT_CRS: "EPSG:4326"
     }
 
     def __init__(self):

--- a/LDMP/conf.py
+++ b/LDMP/conf.py
@@ -58,6 +58,7 @@ class Setting(enum.Enum):
     BASE_DIR = "advanced/base_data_directory"
     CUSTOM_CRS_ENABLED = "region_of_interest/custom_crs_enabled"
     CUSTOM_CRS = "region_of_interest/custom_crs"
+    CUSTOM_CRS_WRAP = "region_of_interest/custom_crs_wrap"
     POLL_REMOTE = "advanced/poll_remote_server"
     REMOTE_POLLING_FREQUENCY = "advanced/remote_polling_frequency_seconds"
     DOWNLOAD_RESULTS = "advanced/download_remote_results_automatically"
@@ -111,6 +112,7 @@ class SettingsManager:
         ),
         Setting.CUSTOM_CRS_ENABLED: False,
         Setting.CUSTOM_CRS: "epsg:4326",
+        Setting.CUSTOM_CRS_WRAP: False,
         Setting.POLL_REMOTE: True,
         Setting.DOWNLOAD_RESULTS: True,
         Setting.BUFFER_CHECKED: False,
@@ -233,7 +235,7 @@ def settings_crs_as_wkt():
         return ""
 
     return crs.toWkt(
-        qgis.core.QgsCoordinateReferenceSystem.WktVariant.WKT_PREFERRED_GDAL
+        qgis.core.QgsCoordinateReferenceSystem.WktVariant.WKT1_GDAL
     )
 
 

--- a/LDMP/conf.py
+++ b/LDMP/conf.py
@@ -87,7 +87,6 @@ class Setting(enum.Enum):
     LC_LAST_DIR = "land_cover/last_dir"
     LC_IPCC_NESTING = "land_cover/ipcc_nesting"
     LC_ESA_NESTING = "land_cover/esa_nesting"
-    DEFAULT_CRS = "crs/default"
 
 
 class SettingsManager:
@@ -137,8 +136,7 @@ class SettingsManager:
         Setting.LC_MAX_CLASSES: 45,
         Setting.LC_LAST_DIR: "",
         Setting.LC_IPCC_NESTING: "",
-        Setting.LC_ESA_NESTING: "",
-        Setting.DEFAULT_CRS: "EPSG:4326"
+        Setting.LC_ESA_NESTING: ""
     }
 
     def __init__(self):
@@ -203,6 +201,39 @@ def _load_algorithm_config(
 
     return algorithm_models.AlgorithmGroup(
         name="root", name_details="root_details", parent=None, groups=top_level_groups
+    )
+
+
+def settings_crs() -> qgis.core.QgsCoordinateReferenceSystem:
+    """
+    Returns the CRS stored in settings or None if settings is not defined
+    or if the CRS is invalid.
+    """
+    crs_str = settings_manager.get_value(Setting.CUSTOM_CRS)
+    if not crs_str:
+        return None
+
+    crs = qgis.core.QgsCoordinateReferenceSystem(crs_str)
+    if not crs.isValid():
+        return None
+
+    return crs
+
+
+def settings_crs_as_wkt():
+    """
+    Returns the CRS stored in settings as a WKT string or an empty string
+    if the CRS is not defined or is invalid.
+    The variant of the WKT is biased for use with the GDAL library, else
+    this can be changed by specifying the
+    QgsCoordinateReferenceSystem.WktVariant flag.
+    """
+    crs = settings_crs()
+    if not crs:
+        return ""
+
+    return crs.toWkt(
+        qgis.core.QgsCoordinateReferenceSystem.WktVariant.WKT_PREFERRED_GDAL
     )
 
 

--- a/LDMP/data_io.py
+++ b/LDMP/data_io.py
@@ -974,7 +974,7 @@ class DlgDataIOImportBase(QtWidgets.QDialog):
 
     def get_resample_mode(self, f):
         in_res = self.get_in_res_wgs84()
-        out_res = self.get_out_res_wgs84()
+        out_res = self.get_out_res_in_metres()
 
         if in_res < out_res:
             if self.datatype == "categorical":
@@ -1043,14 +1043,18 @@ class DlgDataIOImportBase(QtWidgets.QDialog):
 
         return ((lrx - ulx) / float(x_size) + (lry - uly) / float(y_size)) / 2
 
-    def get_out_res_wgs84(self):
+    def get_out_res_in_metres(self):
         # Calculate res in degrees from input which is in meters
+        crs = self.settings_crs()
         res = int(self.input_widget.spinBox_resolution.value())
+
+        if not crs.isGeographic():
+            return res
 
         return res / (111.325 * 1000)  # 111.325km in one degree
 
     def remap_vector(self, l, out_file, remap_dict, attribute):
-        out_res = None # self.get_out_res_wgs84()
+        out_res = self.get_out_res_in_metres()
         log(
             'Remapping and rasterizing {} using output resolution {}, and field "{}"'.format(
                 out_file, out_res, attribute
@@ -1100,7 +1104,7 @@ class DlgDataIOImportBase(QtWidgets.QDialog):
             return True
 
     def rasterize_vector(self, in_file, out_file, attribute):
-        out_res = self.get_out_res_wgs84()
+        out_res = self.get_out_res_in_metres()
         log(
             f"Rasterizing {out_file} using output resolution {out_res}, "
             f'and field "{attribute}"'

--- a/LDMP/gui/DlgSettings.ui
+++ b/LDMP/gui/DlgSettings.ui
@@ -183,6 +183,20 @@
         </widget>
        </item>
        <item>
+        <widget class="QgsCollapsibleGroupBox" name="groupbox_crs">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="title">
+          <string>CRS</string>
+         </property>
+         <layout class="QVBoxLayout" name="crs_layout"/>
+        </widget>
+       </item>
+       <item>
         <widget class="QgsCollapsibleGroupBox" name="groupbox_lc_config">
          <property name="minimumSize">
           <size>

--- a/LDMP/gui/WidgetSettingsCrs.ui
+++ b/LDMP/gui/WidgetSettingsCrs.ui
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>WidgetSettingsCrs</class>
+ <widget class="QWidget" name="WidgetSettingsCrs">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>500</width>
+    <height>54</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Default CRS for datasets</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QgsProjectionSelectionWidget" name="proj_selector"/>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsProjectionSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsprojectionselectionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/LDMP/jobs/manager.py
+++ b/LDMP/jobs/manager.py
@@ -470,6 +470,7 @@ class JobManager(QtCore.QObject):
         final_params["local_context"] = (
             jobs.JobLocalContext().Schema().dump(_get_local_context())
         )
+        final_params["crs"] = conf.settings_crs_as_wkt()
         url_fragment = f"/api/v1/script/{script_id}/run"
         response = self.api_client.call_api(
             url_fragment, "post", final_params, use_token=True

--- a/LDMP/localexecution/soilorganiccarbon.py
+++ b/LDMP/localexecution/soilorganiccarbon.py
@@ -69,16 +69,18 @@ def compute_soil_organic_carbon(
 
     in_vrt_path = tempfile.NamedTemporaryFile(suffix=".vrt").name
     LDMP.logger.log("Saving SOC input files to {}".format(in_vrt_path))
+    bounds = area_of_interest.get_aligned_output_bounds_deprecated(
+        lc_initial_vrt
+    )
     gdal.BuildVRT(
         in_vrt_path,
         in_files,
         resolution="highest",
         resampleAlg=gdal.GRA_NearestNeighbour,
-        outputBounds=area_of_interest.get_aligned_output_bounds_deprecated(
-            lc_initial_vrt
-        ),
+        outputBounds=bounds,
         separate=True,
     )
+
     LDMP.logger.log(f"Saving soil organic carbon to {dataset_output_path!r}")
     # Lc bands start on band 3 as band 1 is initial soc, and band 2 is
     # climate zones

--- a/LDMP/plugin.py
+++ b/LDMP/plugin.py
@@ -336,7 +336,10 @@ class LDMPPlugin:
     def run_settings(self):
         old_base_dir = conf.settings_manager.get_value(conf.Setting.BASE_DIR)
 
-        self.iface.showOptionsDialog(currentPage=OPTIONS_TITLE)
+        self.iface.showOptionsDialog(
+            self.iface.mainWindow(),
+            currentPage=OPTIONS_TITLE
+        )
 
         new_base_dir = conf.settings_manager.get_value(conf.Setting.BASE_DIR)
         if old_base_dir != new_base_dir:

--- a/LDMP/settings.py
+++ b/LDMP/settings.py
@@ -238,6 +238,11 @@ class TrendsEarthSettings(Ui_DlgSettings, QgsOptionsPageWidget):
             if hasattr(self, "dock_widget") and self.dock_widget.isVisible():
                 self.dock_widget.refresh_after_cache_update()
 
+        # There are cases where you can modify settings without activating
+        # the dock widget.
+        if not hasattr(self, "dock_widget") or not self.dock_widget:
+            return
+
         offline_mode = settings_manager.get_value(Setting.OFFLINE_MODE)
         if offline_mode:
             self.dock_widget.pushButton_download.setEnabled(False)

--- a/LDMP/settings.py
+++ b/LDMP/settings.py
@@ -229,7 +229,6 @@ class TrendsEarthSettings(Ui_DlgSettings, QgsOptionsPageWidget):
         self.widget_settings_report.save_settings()
         self.widget_crs_settings.save_settings()
         if not self.lcc_manager.save_settings():
-            print("Validation failed")
             return
 
         new_base_dir = conf.settings_manager.get_value(conf.Setting.BASE_DIR)
@@ -1601,22 +1600,17 @@ class WidgetSettingsCrs(QtWidgets.QWidget, Ui_WidgetSettingsCrs):
         )
 
     def _load_crs_from_settings(self):
-        crs_str = settings_manager.get_value(Setting.DEFAULT_CRS)
-        if not crs_str:
-            # Default to WGS84 if settings was empty
-            settings_crs = qgis.core.QgsCoordinateReferenceSystem("EPSG:4326")
-        else:
-            settings_crs = qgis.core.QgsCoordinateReferenceSystem(crs_str)
-            if not settings_crs.isValid():
-                msg_level = qgis.core.Qgis.MessageLevel.Warning
-                msg = self.tr("Previously saved CRS is not valid.")
-                self.msg_bar.pushMessage(
-                    self.tr("CRS"),
-                    msg,
-                    msg_level,
-                    5
-                )
-        self.proj_selector.setCrs(settings_crs)
+        crs = conf.settings_crs()
+        if not crs:
+            msg_level = qgis.core.Qgis.MessageLevel.Warning
+            msg = self.tr("Previously saved CRS is not defined or invalid.")
+            self.msg_bar.pushMessage(
+                self.tr("CRS"),
+                msg,
+                msg_level,
+                5
+            )
+        self.proj_selector.setCrs(crs)
 
     def showEvent(self, event):
         super().showEvent(event)
@@ -1632,7 +1626,7 @@ class WidgetSettingsCrs(QtWidgets.QWidget, Ui_WidgetSettingsCrs):
             crs_str = crs.authid()
 
         settings_manager.write_value(
-            Setting.DEFAULT_CRS,
+            Setting.CUSTOM_CRS,
             crs_str
         )
 


### PR DESCRIPTION
Hi @azvoleff,

Please see the work related to #717. 

For remote tasks, there is a `crs` key added in params that contains the CRS in WKT format using the legacy `WKT1_GDAL` flag. See more options [here](https://api.qgis.org/api/3.28/classQgsCoordinateReferenceSystem.html#ac2bb97dcdc388cfe88479eb836a81b7c) which are dependent on the version of the Proj library.

For locally run tasks, the system now validates whether the input layers are in the same projection as that defined in settings. Also, the `AOI` object from `areaofinterest.prepare_area_of_interest` now uses the CRS from settings. This (AOI) object is cascaded to the respective algorithms.

On supporting importation of datasets, this is not fully implemented as it is dependent on PR #757 but have attempted to refactor some of the sections that explicitly used WGS84. One question is to how to handle the respective input and output resolution computations since there will be no CRS conversion to WGS84 taking place as was the case before.