### PR TITLE
Update on code format workflow

### DIFF
--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -15,4 +15,4 @@ jobs:
           pip install ruff
       # Update output format to enable automatic inline annotations.
       - name: Run Ruff
-        run: ruff check --output-format=github .
+        run: ruff check --output-format=github --exclude=gee .


### PR DESCRIPTION
Excludes the GEE library https://github.com/ConservationInternational/trends.earth-gee when checking for repository code formatting.