### PR TITLE
QGIS CI docker images update

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,7 +31,8 @@ jobs:
         qgis_version_tag:
           - release-3_22
           - release-3_26
-          - latest
+          - release-3_34
+          - release-3_36
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Added QGIS latest LTS version(3.34) and remove faulty QGIS docker `latest` image for CI runs