### PR TITLE
Enable date filtering in the datasets items

### DIFF
--- a/LDMP/conf.py
+++ b/LDMP/conf.py
@@ -52,6 +52,10 @@ class Setting(enum.Enum):
     UNKNOWN_AREA_OF_INTEREST = "private/unknown_area_of_interest"
     PRIOR_LOCALE = "private/prior_locale"
 
+    DATE_FILTER_ENABLED = "filters/date_filter_enabled"
+    FILTER_START_DATE = "filters/start_date"
+    FILTER_END_DATE = "filters/end_date"
+
     DEBUG = "advanced/debug"
     BINARIES_ENABLED = "advanced/binaries_enabled"
     BINARIES_DIR = "advanced/binaries_folder"
@@ -116,6 +120,9 @@ class SettingsManager:
         Setting.CUSTOM_CRS: "epsg:4326",
         Setting.POLL_REMOTE: True,
         Setting.DOWNLOAD_RESULTS: True,
+        Setting.DATE_FILTER_ENABLED: False,
+        Setting.FILTER_START_DATE: "",
+        Setting.FILTER_END_DATE: "",
         Setting.BUFFER_CHECKED: False,
         Setting.AREA_FROM_OPTION: AreaSetting.COUNTRY_REGION.value,
         Setting.POINT_X: 0.0,

--- a/LDMP/dataset_additional_metadata.py
+++ b/LDMP/dataset_additional_metadata.py
@@ -1,5 +1,4 @@
 import os
-
 from pathlib import Path
 
 from qgis.PyQt import QtCore, QtGui, QtWidgets, uic
@@ -24,7 +23,7 @@ class DataSetAdditionalMetadataDialog(QtWidgets.QDialog, DatasetAdditionalMetada
     def __init__(self, dataset: dict, parent=None):
         super().__init__(parent)
         self.setupUi(self)
-        self.le_title.setText(dataset.get('title', ''))
-        self.te_author.setPlainText(dataset.get('Data source', ''))
-        self.le_source.setText(dataset.get('Source', ''))
-        self.te_citation.setPlainText(dataset.get('Citation', ''))
+        self.le_title.setText(dataset.get("title", ""))
+        self.te_author.setPlainText(dataset.get("Data source", ""))
+        self.le_source.setText(dataset.get("Source", ""))
+        self.te_citation.setPlainText(dataset.get("Citation", ""))

--- a/LDMP/dataset_additional_metadata.py
+++ b/LDMP/dataset_additional_metadata.py
@@ -1,0 +1,30 @@
+import os
+
+from pathlib import Path
+
+from qgis.PyQt import QtCore, QtGui, QtWidgets, uic
+
+from LDMP.utils import log
+
+DatasetAdditionalMetadataUi, _ = uic.loadUiType(
+    str(Path(__file__).parents[0] / "gui/DlgDatasetAdditionalMetadata.ui")
+)
+
+ICON_PATH = os.path.join(os.path.dirname(__file__), "icons")
+
+
+class DataSetAdditionalMetadataDialog(QtWidgets.QDialog, DatasetAdditionalMetadataUi):
+    dataset: dict
+
+    le_title: QtWidgets.QLineEdit
+    te_author: QtWidgets.QTextEdit
+    le_source: QtWidgets.QLineEdit
+    te_citation: QtWidgets.QTextEdit
+
+    def __init__(self, dataset: dict, parent=None):
+        super().__init__(parent)
+        self.setupUi(self)
+        self.le_title.setText(dataset.get('title', ''))
+        self.te_author.setPlainText(dataset.get('Data source', ''))
+        self.le_source.setText(dataset.get('Source', ''))
+        self.te_citation.setPlainText(dataset.get('Citation', ''))

--- a/LDMP/dataset_additional_metadata.py
+++ b/LDMP/dataset_additional_metadata.py
@@ -1,9 +1,7 @@
 import os
 from pathlib import Path
 
-from qgis.PyQt import QtCore, QtGui, QtWidgets, uic
-
-from LDMP.utils import log
+from qgis.PyQt import QtWidgets, uic
 
 DatasetAdditionalMetadataUi, _ = uic.loadUiType(
     str(Path(__file__).parents[0] / "gui/DlgDatasetAdditionalMetadata.ui")

--- a/LDMP/download_data.py
+++ b/LDMP/download_data.py
@@ -14,10 +14,13 @@
 import json
 import os
 from pathlib import Path
+from functools import partial
 
 import qgis.gui
 from qgis.PyQt import QtCore, QtGui, QtWidgets, uic
 from te_schemas.algorithms import ExecutionScript
+
+from .dataset_additional_metadata import DataSetAdditionalMetadataDialog
 
 from . import calculate, conf
 from .conf import Setting, settings_manager
@@ -185,7 +188,8 @@ class DlgDownload(calculate.DlgCalculateBase, DlgDownloadUi):
         # Add "Notes" buttons in cell
         for row in range(0, len(self.datasets)):
             btn = QtWidgets.QPushButton(self.tr("Details"))
-            btn.clicked.connect(self.btn_details)
+            btn_details = partial(self.btn_details, self.datasets[row])
+            btn.clicked.connect(btn_details)
             self.data_view.setIndexWidget(self.proxy_model.index(row, 8), btn)
 
         # Category
@@ -227,11 +231,12 @@ class DlgDownload(calculate.DlgCalculateBase, DlgDownloadUi):
 
         self.data_view.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectRows)
 
-    def btn_details(self):
+    def btn_details(self, dataset):
         # button = self.sender()
         # index = self.data_view.indexAt(button.pos())
         # TODO: Code the details view
-        pass
+        dlg = DataSetAdditionalMetadataDialog(dataset)
+        dlg.exec()
 
     def btn_calculate(self):
         # Note that the super class has several tests in it - if they fail it

--- a/LDMP/download_data.py
+++ b/LDMP/download_data.py
@@ -13,17 +13,16 @@
 
 import json
 import os
-from pathlib import Path
 from functools import partial
+from pathlib import Path
 
 import qgis.gui
 from qgis.PyQt import QtCore, QtGui, QtWidgets, uic
 from te_schemas.algorithms import ExecutionScript
 
-from .dataset_additional_metadata import DataSetAdditionalMetadataDialog
-
 from . import calculate, conf
 from .conf import Setting, settings_manager
+from .dataset_additional_metadata import DataSetAdditionalMetadataDialog
 from .jobs.manager import job_manager
 from .logger import log
 

--- a/LDMP/gui/DlgDatasetAdditionalMetadata.ui
+++ b/LDMP/gui/DlgDatasetAdditionalMetadata.ui
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>706</width>
+    <height>577</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Additional Metadata</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>6</number>
+   </property>
+   <property name="topMargin">
+    <number>6</number>
+   </property>
+   <property name="rightMargin">
+    <number>6</number>
+   </property>
+   <property name="bottomMargin">
+    <number>6</number>
+   </property>
+   <item>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>694</width>
+        <height>565</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QgsCollapsibleGroupBox" name="groupBox">
+         <property name="title">
+          <string>Metadata</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout">
+          <item row="8" column="0">
+           <widget class="QTextEdit" name="te_citation">
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0" colspan="3">
+           <widget class="QLineEdit" name="le_title">
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0">
+           <widget class="QLineEdit" name="le_source">
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Title</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0" colspan="3">
+           <widget class="QTextEdit" name="te_author">
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="0">
+           <widget class="QLabel" name="label_3">
+            <property name="text">
+             <string>Bibliographical Citation</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0" colspan="2">
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string>Author or Publisher</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="label_4">
+            <property name="text">
+             <string>Source Link or Identifier</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>scrollArea</tabstop>
+  <tabstop>le_title</tabstop>
+  <tabstop>te_author</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>

--- a/LDMP/gui/WidgetMain.ui
+++ b/LDMP/gui/WidgetMain.ui
@@ -18,7 +18,7 @@
     <item>
      <widget class="QTabWidget" name="tabWidget">
       <property name="currentIndex">
-       <number>0</number>
+       <number>1</number>
       </property>
       <widget class="QWidget" name="tab_algorithms">
        <attribute name="title">
@@ -41,7 +41,7 @@
        <attribute name="title">
         <string>Datasets</string>
        </attribute>
-       <layout class="QVBoxLayout" name="verticalLayout_3" stretch="0,0,0">
+       <layout class="QVBoxLayout" name="verticalLayout_3">
         <item>
          <layout class="QHBoxLayout" name="horizontalLayout">
           <item>
@@ -65,7 +65,7 @@ for running algorithms and their results.</string>
             <property name="placeholderText">
              <string>Search...</string>
             </property>
-            <property name="showSearchIcon" stdset="0">
+            <property name="showSearchIcon">
              <bool>true</bool>
             </property>
             <property name="qgisRelation" stdset="0">
@@ -81,6 +81,79 @@ for running algorithms and their results.</string>
            </widget>
           </item>
          </layout>
+        </item>
+        <item>
+         <widget class="QgsCollapsibleGroupBox" name="date_filter_group">
+          <property name="toolTip">
+           <string/>
+          </property>
+          <property name="title">
+           <string>Filter by date</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+          <property name="collapsed">
+           <bool>true</bool>
+          </property>
+          <layout class="QGridLayout" name="gridLayout_2">
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_13">
+             <property name="text">
+              <string>Start</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QLabel" name="label_14">
+             <property name="text">
+              <string>End</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QgsDateTimeEdit" name="start_dte">
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="dateTime">
+              <datetime>
+               <hour>0</hour>
+               <minute>0</minute>
+               <second>0</second>
+               <year>2021</year>
+               <month>1</month>
+               <day>1</day>
+              </datetime>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QgsDateTimeEdit" name="end_dte">
+             <property name="dateTime">
+              <datetime>
+               <hour>0</hour>
+               <minute>0</minute>
+               <second>0</second>
+               <year>2021</year>
+               <month>12</month>
+               <day>1</day>
+              </datetime>
+             </property>
+             <property name="date">
+              <date>
+               <year>2021</year>
+               <month>12</month>
+               <day>1</day>
+              </date>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
         </item>
         <item>
          <widget class="QTreeView" name="datasets_tv">
@@ -155,9 +228,20 @@ for running algorithms and their results.</string>
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsDateTimeEdit</class>
+   <extends>QDateTimeEdit</extends>
+   <header>qgsdatetimeedit.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsFilterLineEdit</class>
    <extends>QLineEdit</extends>
-   <header>qgis.gui</header>
+   <header>qgsfilterlineedit.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/LDMP/jobs/mvc.py
+++ b/LDMP/jobs/mvc.py
@@ -129,12 +129,14 @@ class JobsSortFilterProxyModel(QtCore.QSortFilterProxyModel):
         matches_date = True
         if self.start_date and self.end_date:
             job_start_date = QtCore.QDateTime.fromString(
-                job.start_date.strftime("%Y-%m-%d %H:%M:%S"),
-                "yyyy-MM-dd HH:mm:ss")
+                job.start_date.strftime("%Y-%m-%d %H:%M:%S"), "yyyy-MM-dd HH:mm:ss"
+            )
             job_end_date = QtCore.QDateTime.fromString(
-                job.end_date.strftime("%Y-%m-%d %H:%M:%S"),
-                "yyyy-MM-dd HH:mm:ss")
-            matches_date = job_start_date >= self.start_date and job_end_date <= self.end_date
+                job.end_date.strftime("%Y-%m-%d %H:%M:%S"), "yyyy-MM-dd HH:mm:ss"
+            )
+            matches_date = (
+                job_start_date >= self.start_date and job_end_date <= self.end_date
+            )
 
         return matches_filter and matches_type and matches_date
 

--- a/LDMP/jobs/mvc.py
+++ b/LDMP/jobs/mvc.py
@@ -99,6 +99,13 @@ class JobsSortFilterProxyModel(QtCore.QSortFilterProxyModel):
     def __init__(self, current_sort_field: SortField, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.current_sort_field = current_sort_field
+        self.start_date = None
+        self.end_date = None
+
+    def set_date_filter(self, start_date, end_date):
+        self.start_date = start_date
+        self.end_date = end_date
+        self.invalidateFilter()
 
     def filterAcceptsRow(self, source_row: int, source_parent: QtCore.QModelIndex):
         jobs_model = self.sourceModel()
@@ -118,7 +125,14 @@ class JobsSortFilterProxyModel(QtCore.QSortFilterProxyModel):
         elif self.type_filter == TypeFilter.VECTOR:
             matches_type = job.is_vector()
 
-        return matches_filter and matches_type
+        # Date filtering logic
+        matches_date = True
+        if self.start_date and self.end_date:
+            job_start_date = QtCore.QDate.fromString(job.start_date, "yyyy-MM-dd")
+            job_end_date = QtCore.QDate.fromString(job.end_date, "yyyy-MM-dd")
+            matches_date = job_start_date >= self.start_date and job_end_date <= self.end_date
+
+        return matches_filter and matches_type and matches_date
 
     def lessThan(self, left: QtCore.QModelIndex, right: QtCore.QModelIndex) -> bool:
         model = self.sourceModel()

--- a/LDMP/jobs/mvc.py
+++ b/LDMP/jobs/mvc.py
@@ -128,8 +128,12 @@ class JobsSortFilterProxyModel(QtCore.QSortFilterProxyModel):
         # Date filtering logic
         matches_date = True
         if self.start_date and self.end_date:
-            job_start_date = QtCore.QDate.fromString(job.start_date, "yyyy-MM-dd")
-            job_end_date = QtCore.QDate.fromString(job.end_date, "yyyy-MM-dd")
+            job_start_date = QtCore.QDateTime.fromString(
+                job.start_date.strftime("%Y-%m-%d %H:%M:%S"),
+                "yyyy-MM-dd HH:mm:ss")
+            job_end_date = QtCore.QDateTime.fromString(
+                job.end_date.strftime("%Y-%m-%d %H:%M:%S"),
+                "yyyy-MM-dd HH:mm:ss")
             matches_date = job_start_date >= self.start_date and job_end_date <= self.end_date
 
         return matches_filter and matches_type and matches_date

--- a/LDMP/main_widget.py
+++ b/LDMP/main_widget.py
@@ -161,6 +161,17 @@ class MainWidget(QtWidgets.QDockWidget, DockWidgetTrendsEarthUi):
             self.pushButton_download.setEnabled(True)
             self.setWindowTitle(DOCK_TITLE)
 
+        self.start_dte.dateChanged(self.date_filter_changed)
+        self.end_dte.dateChanged(self.date_filter_changed)
+
+
+    def date_filter_changed(self):
+        start_date = self.start_dte.dateTime()
+        end_date = self.end_date.dateTime()
+
+        if self.proxy_model:
+            self.proxy_model.set_date_filter(start_date, end_date)
+
     def setup_datasets_page_gui(self):
         self.pushButton_refresh.setIcon(
             QtGui.QIcon(os.path.join(ICON_PATH, "mActionRefresh.svg"))

--- a/LDMP/main_widget.py
+++ b/LDMP/main_widget.py
@@ -163,28 +163,22 @@ class MainWidget(QtWidgets.QDockWidget, DockWidgetTrendsEarthUi):
             self.pushButton_download.setEnabled(True)
             self.setWindowTitle(DOCK_TITLE)
 
-        date_filter_enabled = settings_manager.get_value(
-            Setting.DATE_FILTER_ENABLED
-        )
+        date_filter_enabled = settings_manager.get_value(Setting.DATE_FILTER_ENABLED)
 
         if not date_filter_enabled:
             date_filter_enabled = False
 
-        self.date_filter_group.setChecked(
-            date_filter_enabled
-        )
+        self.date_filter_group.setChecked(date_filter_enabled)
 
-        settings_start_date = settings_manager.get_value(
-            Setting.FILTER_START_DATE
-        )
-        settings_end_date = settings_manager.get_value(
-            Setting.FILTER_END_DATE
-        )
+        settings_start_date = settings_manager.get_value(Setting.FILTER_START_DATE)
+        settings_end_date = settings_manager.get_value(Setting.FILTER_END_DATE)
         if settings_start_date != "" and settings_end_date != "":
             start_date = QtCore.QDateTime.fromString(
-                settings_start_date, "yyyy-MM-dd HH:mm:ss")
+                settings_start_date, "yyyy-MM-dd HH:mm:ss"
+            )
             end_date = QtCore.QDateTime.fromString(
-                settings_end_date, "yyyy-MM-dd HH:mm:ss")
+                settings_end_date, "yyyy-MM-dd HH:mm:ss"
+            )
 
             self.start_dte.setDateTime(start_date)
             self.end_dte.setDateTime(end_date)
@@ -194,21 +188,18 @@ class MainWidget(QtWidgets.QDockWidget, DockWidgetTrendsEarthUi):
         self.end_dte.dateChanged.connect(self.date_filter_changed)
 
     def date_filter_group_toggled(self, value):
-        settings_manager.write_value(
-            Setting.DATE_FILTER_ENABLED,
-            value
-        )
+        settings_manager.write_value(Setting.DATE_FILTER_ENABLED, value)
         self.date_filter_changed(disabled=not value)
 
     def date_filter_changed(self, disabled=False):
         settings_manager.write_value(
             Setting.FILTER_START_DATE,
-            self.start_dte.dateTime().toString("yyyy-MM-dd HH:mm:ss")
+            self.start_dte.dateTime().toString("yyyy-MM-dd HH:mm:ss"),
         )
 
         settings_manager.write_value(
             Setting.FILTER_END_DATE,
-            self.end_dte.dateTime().toString("yyyy-MM-dd HH:mm:ss")
+            self.end_dte.dateTime().toString("yyyy-MM-dd HH:mm:ss"),
         )
 
         start_date = self.start_dte.dateTime() if not disabled else None

--- a/LDMP/main_widget.py
+++ b/LDMP/main_widget.py
@@ -336,7 +336,7 @@ class MainWidget(QtWidgets.QDockWidget, DockWidgetTrendsEarthUi):
         # self.datasets_tv.setModel(model)
         self.proxy_model = jobs_mvc.JobsSortFilterProxyModel(SortField.DATE)
         self.type_filter_changed(TypeFilter.ALL)
-        self.date_filter_changed()
+        # self.date_filter_changed(not self.date_filter_group.isChecked())
 
         self.filter_changed("")
         action = self.filter_menu.actions()[0]

--- a/LDMP/main_widget.py
+++ b/LDMP/main_widget.py
@@ -164,7 +164,6 @@ class MainWidget(QtWidgets.QDockWidget, DockWidgetTrendsEarthUi):
         self.start_dte.dateChanged.connect(self.date_filter_changed)
         self.end_dte.dateChanged.connect(self.date_filter_changed)
 
-
     def date_filter_changed(self):
         start_date = self.start_dte.dateTime()
         end_date = self.end_dte.dateTime()

--- a/LDMP/main_widget.py
+++ b/LDMP/main_widget.py
@@ -184,8 +184,10 @@ class MainWidget(QtWidgets.QDockWidget, DockWidgetTrendsEarthUi):
             self.end_dte.setDateTime(end_date)
 
         self.date_filter_group.toggled.connect(self.date_filter_group_toggled)
-        self.start_dte.dateChanged.connect(self.date_filter_changed)
-        self.end_dte.dateChanged.connect(self.date_filter_changed)
+        date_filter_enabled = functools.partial(self.date_filter_changed, False)
+
+        self.start_dte.dateChanged.connect(date_filter_enabled)
+        self.end_dte.dateChanged.connect(date_filter_enabled)
 
     def date_filter_group_toggled(self, value):
         settings_manager.write_value(Setting.DATE_FILTER_ENABLED, value)
@@ -336,7 +338,7 @@ class MainWidget(QtWidgets.QDockWidget, DockWidgetTrendsEarthUi):
         # self.datasets_tv.setModel(model)
         self.proxy_model = jobs_mvc.JobsSortFilterProxyModel(SortField.DATE)
         self.type_filter_changed(TypeFilter.ALL)
-        # self.date_filter_changed(not self.date_filter_group.isChecked())
+        self.date_filter_changed(disabled=not self.date_filter_group.isChecked())
 
         self.filter_changed("")
         action = self.filter_menu.actions()[0]

--- a/LDMP/main_widget.py
+++ b/LDMP/main_widget.py
@@ -161,13 +161,13 @@ class MainWidget(QtWidgets.QDockWidget, DockWidgetTrendsEarthUi):
             self.pushButton_download.setEnabled(True)
             self.setWindowTitle(DOCK_TITLE)
 
-        self.start_dte.dateChanged(self.date_filter_changed)
-        self.end_dte.dateChanged(self.date_filter_changed)
+        self.start_dte.dateChanged.connect(self.date_filter_changed)
+        self.end_dte.dateChanged.connect(self.date_filter_changed)
 
 
     def date_filter_changed(self):
         start_date = self.start_dte.dateTime()
-        end_date = self.end_date.dateTime()
+        end_date = self.end_dte.dateTime()
 
         if self.proxy_model:
             self.proxy_model.set_date_filter(start_date, end_date)


### PR DESCRIPTION
Fixes https://github.com/ConservationInternational/trends.earth/issues/819.

Adds a new date filter group box with input for start and end datetime used to filter the datasets list and a dialog for additional metadata from the download tool

Screenshot of the date filter group box

![date_filter_group](https://github.com/user-attachments/assets/974f3471-6fb6-40bc-810f-cabd8cef262c)


Screenshot of the additional metadata group box

![image](https://github.com/user-attachments/assets/ff8e5dea-cfed-4daa-9624-a0fcf4bb356b)


