### PR TITLE
Disable PR comments addition

### DIFF
--- a/.github/workflows/pr_package.yml
+++ b/.github/workflows/pr_package.yml
@@ -64,30 +64,3 @@ jobs:
         with:
           name: ${{ env.ZIP_NAME }}
           path: ${{ env.ZIP_PATH }}
-
-      - name: Find Comment
-        uses: peter-evans/find-comment@v2
-        id: find-comment
-        with:
-          issue-number: ${{ github.event.number }}
-          comment-author: 'github-actions[bot]'
-
-      - name: Update Comment
-        env:
-          HEAD_SHA: "${{ github.event.head_sha }}"
-          ARTIFACT_URL: ${{ steps.artifact-upload-step.outputs.artifact-url }}
-
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          token: ${{ github.token }}
-          issue-number: ${{ github.event.number }}
-          comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          edit-mode: replace
-          body: |-
-            ![badge]
-            
-            Plugin zip package for the changes in this PR has been successfully built!.
-            
-            Download the plugin zip file here ${{ env.ARTIFACT_URL }}
-            
-            [badge]: https://img.shields.io/badge/package_build-success-green


### PR DESCRIPTION
Currently the action responsible for creating a PR plugin artifact, fails to add a comment with the artifact information in the PR due to insufficient permissions. This PR removes the commenting step until the action is able to get access to the PR resources.