### PR TITLE
Fix LC transition matrix table reset

### DIFF
--- a/LDMP/lc_setup.py
+++ b/LDMP/lc_setup.py
@@ -1193,7 +1193,7 @@ class LCDefineDegradationWidget(QtWidgets.QWidget, WidgetLcDefineDegradationUi):
         )
 
         self.btn_transmatrix_reset.clicked.connect(
-            lambda: self.set_trans_matrix(get_default=False)
+            lambda: self.set_trans_matrix(get_default=True)
         )
         self.btn_transmatrix_loadfile.clicked.connect(self.trans_matrix_loadfile)
         self.btn_transmatrix_savefile.clicked.connect(self.trans_matrix_savefile)


### PR DESCRIPTION
Fixes https://github.com/ConservationInternational/trends.earth/issues/827

Makes sure the LC transition matrix table is fully reset when user click the "Reset table" button

Screenshot
![reset_matrix_table_fix](https://github.com/user-attachments/assets/c6d7c9da-9611-4e61-843e-dad80d112d64)
