### PR TITLE
Fix the comments creation workflow

### DIFF
--- a/.github/workflows/comment_pr_package.yaml
+++ b/.github/workflows/comment_pr_package.yaml
@@ -5,7 +5,7 @@ on:
     types:
       - completed
     workflows:
-      - 'Creating plugin package in the PR'
+      - 'Create plugin package in the PR'
 
 jobs:
   comment:


### PR DESCRIPTION
Update the used PR package workflow name, from  ` Creating plugin package in the PR` to  `Create plugin package in the PR`