### PR TITLE
fix: urban change summary table for city process fails to run

### DIFF
--- a/LDMP/calculate_urban.py
+++ b/LDMP/calculate_urban.py
@@ -277,7 +277,7 @@ class DlgCalculateUrbanSummaryTable(
         urban_indices_years = []
         pop_indices_years = []
 
-        for index, band in enumerate(urban_usable_info.job.results.bands):
+        for index, band in enumerate(urban_usable_info.job.results.get_bands()):
             band_index = index + 1
             band_year = band.metadata.get("year")
             if band.name.lower() == "urban":


### PR DESCRIPTION
The `DlgCalculateUrbanSummaryTable` class was trying to get the bands for iteration from the `bands` attribute of the class `RasterResults`. `bands` is not an attribute of `RasterResults`, but the classes bands can be received using its `get_bands()` method. This method is now used to get the bands to iterate over. 

Closes #902. 