### PR TITLE
Make reports work in FAO-WOCAT productivity mode for SDG 15.3.1 local task

### DIFF
--- a/LDMP/reports/charts.py
+++ b/LDMP/reports/charts.py
@@ -1066,7 +1066,7 @@ class SdgSummaryJobAttributes:
 
         classes = legend_parent["key"]
         for c in classes:
-            cls_name = c["name_long"]
+            cls_name = c["name_short"]
             pix_val = c["code"]
             clr = QColor(c["color"])
 


### PR DESCRIPTION
The error was:

```
Traceback (most recent call last):
  File "/home/till/.local/share/QGIS/QGIS3/profiles/default/python/plugins/LDMP/reports/generator.py", line 490, in run
    status = self._run()
  File "/home/till/.local/share/QGIS/QGIS3/profiles/default/python/plugins/LDMP/reports/generator.py", line 517, in _run
    self._create_layers()
    ~~~~~~~~~~~~~~~~~~~^^
  File "/home/till/.local/share/QGIS/QGIS3/profiles/default/python/plugins/LDMP/reports/generator.py", line 215, in _create_layers
    self._charts_mgr.add_job_layers(j, layer_band_infos)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
  File "/home/till/.local/share/QGIS/QGIS3/profiles/default/python/plugins/LDMP/reports/charts.py", line 992, in add_job_layers
    chart_config_obj = chart_config_cls(
        job, band_infos, root_output_dir=self._root_output_dir
    )
  File "/home/till/.local/share/QGIS/QGIS3/profiles/default/python/plugins/LDMP/reports/charts.py", line 680, in __init__
    self._add_charts()
    ~~~~~~~~~~~~~~~~^^
  File "/home/till/.local/share/QGIS/QGIS3/profiles/default/python/plugins/LDMP/reports/charts.py", line 827, in _add_charts
    init_lc_value_info_collection = job_attr.land_cover(str(init_year))
  File "/home/till/.local/share/QGIS/QGIS3/profiles/default/python/plugins/LDMP/reports/charts.py", line 1183, in land_cover
    return self.thematic_category_values_by_year(
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        lc_areas, year, self.land_cover_7_class_str_info_mapping()
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/till/.local/share/QGIS/QGIS3/profiles/default/python/plugins/LDMP/reports/charts.py", line 1165, in thematic_category_values_by_year
    ramp_item = category_ramp_item_mapping[lc_type]
                ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
KeyError: 'Bare land'
```

Due to `name_short` and `name_long` differing here: https://github.com/ConservationInternational/trends.earth/blob/7b792dc55296ee649daa8d636f51217d971a46fa/LDMP/data/land_cover_nesting_unccd_esa.json#L42

This PR now grabs `name_short` and makes `"Bare land"` available.