### PR TITLE
enforce prod date triggers + override LC/SOC per JRC (2015-2019 | 2015-2023)

### DIFF
--- a/LDMP/calculate_ldn.py
+++ b/LDMP/calculate_ldn.py
@@ -15,7 +15,6 @@
 import typing
 import weakref
 from dataclasses import dataclass
-from functools import partial
 from pathlib import Path
 
 import qgis.gui


### PR DESCRIPTION
- Make prod date enforcement fire on any user interaction with date fields.
- When LPD is set to precalculated, automatically set LC/SOC windows based on the selected JRC dataset:
   - JRC Land Productivity Dynamics (2004-2019) -> LC/SOC = 2015-2019
   - JRC Land Productivity Dynamics (2008-2023) -> LC/SOC = 2015-2023
   
[Bug fixes #2](https://github.com/ConservationInternational/trends.earth/issues/980)